### PR TITLE
Adding Automation for MAISTRA-2134

### DIFF
--- a/tests/config/excludeOutboundPortsAnnotation/app-v2.yaml
+++ b/tests/config/excludeOutboundPortsAnnotation/app-v2.yaml
@@ -1,0 +1,43 @@
+apiVersion: maistra.io/v1
+kind: ServiceMeshMember
+metadata:
+  name: default
+  namespace: exclude-outboundports-annotation
+spec:
+  controlPlaneRef:
+    name: exclude-outboundports-annotation
+    namespace: istio-system
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: httpbin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: httpbin
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
+        traffic.sidecar.istio.io/excludeOutboundPorts: "443"
+      labels:
+        app: httpbin
+        version: v1
+    spec:
+      initContainers:
+        - name: init
+          image: registry.redhat.io/openshift4/ose-cli
+          imagePullPolicy: Always
+          command: ["/bin/bash"]
+          args:
+          - "-c"
+          - "oc version"
+      containers:
+      - image: quay.io/maistra/httpbin
+        imagePullPolicy: IfNotPresent
+        name: httpbin
+        ports:
+        - containerPort: 8000

--- a/tests/samples.go
+++ b/tests/samples.go
@@ -94,6 +94,8 @@ const (
 	smcpName          = "basic"
 	smcpv1API         = "smcp.v1.maistra.io"
 	invalidSMCPFields = "config/smcp-invalid-fields/smcp.yaml"
+	excludeOutboundPortsAnnotation = "config/excludeOutboundPortsAnnotation/app-v2.yaml"
+
 	mustGatherImage   = "registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel7"
 	smmrTest          = "config/smmrTest.yaml"
 )

--- a/tests/test_cases.go
+++ b/tests/test_cases.go
@@ -142,4 +142,8 @@ var testCases = []testing.InternalTest{
 		Name: "36",
 		F:    TestSMMROVN,
 	},
+	testing.InternalTest{
+		Name: "37",
+		F:    TestExcludeOutboundPortsAnnotation,
+	},
 }

--- a/tests/test_excludeOutboundPorts_annotation.go
+++ b/tests/test_excludeOutboundPorts_annotation.go
@@ -1,0 +1,50 @@
+// Copyright 2020 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"maistra/util"
+	"testing"
+	"time"
+
+	"istio.io/pkg/log"
+)
+
+func cleanupExcludeOutboundPortsAnnotation(namespace string) {
+	log.Info("# Cleanup ...")
+	util.KubeDelete(namespace, excludeOutboundPortsAnnotation, kubeconfig)
+	time.Sleep(time.Duration(waitTime*8) * time.Second)
+	util.DeleteOCPNamespace(namespace,kubeconfig)
+}
+
+func TestExcludeOutboundPortsAnnotation(t *testing.T) {
+	defer cleanupExcludeOutboundPortsAnnotation("exclude-outboundports-annotation")
+
+	t.Run("Operator_test_excludeOutboundPortsAnnotation", func(t *testing.T) {
+
+		defer recoverPanic(t)
+
+		util.CreateOCPNamespace("exclude-outboundports-annotation", kubeconfig)
+		log.Info("Automation for MAISTRA-2134. The annotation should pass on 2.0.3 and above")
+		if err := util.KubeApply("exclude-outboundports-annotation", excludeOutboundPortsAnnotation, kubeconfig); err != nil {
+			t.Errorf("Failed to deploy HTTP bin with traffic.sidecar.istio.io/excludeOutboundPorts annotation")
+		}
+		util.CheckPodRunning("exclude-outboundports-annotation", "app=httpbin", kubeconfig)
+
+
+		time.Sleep(time.Duration(waitTime*2) * time.Second)
+
+	})
+}

--- a/tests/util/ocp_utils.go
+++ b/tests/util/ocp_utils.go
@@ -46,6 +46,19 @@ func CreateOCPNamespace(n string, kubeconfig string) error {
 	return nil
 }
 
+
+
+// DeleteOCPNamespace create a kubernetes namespace
+func DeleteOCPNamespace(n string, kubeconfig string) error {
+	if _, err := ShellMuteOutput("oc delete project %s", n); err != nil {
+		if !strings.Contains(err.Error(), "NotFound") {
+			return err
+		}
+	}
+	log.Infof("namespace %s deleted\n", n)
+	return nil
+}
+
 // OcGrantPermission OCP cluster specific requirements for deploying an application with sidecar.
 // This is a temporary permission config
 func OcGrantPermission(account, namespace, kubeconfig string) {


### PR DESCRIPTION
Adding automation to MAISTRA-2134.


Instead of kubectl, I changed to use the default `oc` image.

@cfilleke  this [image](https://catalog.redhat.com/software/containers/openshift4/ose-cli/5cd9ba3f5a13467289f4d51d?container-tabs=gti) has an equivalent in `s390x` and `ppc64le`