### PR TITLE
MAISTRA-2413 Pin version of header-append-filter

### DIFF
--- a/tests/samples_extend.go
+++ b/tests/samples_extend.go
@@ -2321,7 +2321,7 @@ metadata:
   name: header-append
 spec:
   config: test
-  image: quay.io/maistra-dev/header-append-filter:latest
+  image: quay.io/maistra-dev/header-append-filter:2.0
   phase: PostAuthZ
   priority: 1000
   workloadSelector:


### PR DESCRIPTION
We're making some incompatible changes to this filter in 2.1, so we need to reference the 2.0 version for the 2.0 tests