### PR TITLE
Fail fast in util.Inspect()

### DIFF
--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -34,8 +34,7 @@ var (
 // Inspect error handling function
 func Inspect(err error, fMsg, sMsg string, t *testing.T) {
 	if err != nil {
-		Log.Errorf("%s. Error %s", fMsg, err)
-		t.Error(err)
+		t.Fatalf("%s. Error %s", fMsg, err)
 	} else if sMsg != "" {
 		Log.Info(sMsg)
 	}


### PR DESCRIPTION
Use `t.Fatal()` instead of `t.Error()` so that tests are aborted
when encounter an error.