### PR TITLE
OSSM-734: Add test to cover the init container case

### DIFF
--- a/pkg/ossm/initContainer.go
+++ b/pkg/ossm/initContainer.go
@@ -1,0 +1,47 @@
+// Copyright Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ossm
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/maistra/maistra-test-tool/pkg/util"
+)
+
+const (
+	initContainerNS         = "bookinfo"
+	initContainerGoldString = "init worked"
+)
+
+func cleanupInitContainer() {
+	util.KubeDeleteContents(initContainerNS, testInitContainerYAML)
+}
+
+func TestInitContainer(t *testing.T) {
+	defer cleanupInitContainer()
+
+	if err := util.KubeApplyContents(initContainerNS, testInitContainerYAML); err != nil {
+		t.Fatalf("error creating the pod: %v", err)
+	}
+	if err := util.CheckPodRunning(initContainerNS, "app=sleep-init"); err != nil {
+		t.Fatalf("sleep-init pod is not running: %v", err)
+	}
+
+	logs := util.GetPodLogsForLabel(initContainerNS, "app=sleep-init", "init", false, false)
+	if !strings.Contains(logs, initContainerGoldString) {
+		t.Fatalf("expected init container log to contain the string %q, but got %q", initContainerGoldString, logs)
+	}
+}

--- a/pkg/ossm/yaml_configs.go
+++ b/pkg/ossm/yaml_configs.go
@@ -217,4 +217,36 @@ spec:
         env:
           maistra_test_foo: maistra_test_bar
 `
+
+	testInitContainerYAML = `
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: sleep-init
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: sleep-init
+    template:
+      metadata:
+        annotations:
+          sidecar.istio.io/inject: "true"
+        labels:
+          app: sleep-init
+      spec:
+        terminationGracePeriodSeconds: 0
+
+        initContainers:
+        - name: init
+          image: curlimages/curl
+          command: ["/bin/echo", "init worked"]
+          imagePullPolicy: IfNotPresent
+
+        containers:
+        - name: sleep
+          image: curlimages/curl
+          command: ["/bin/sleep", "3650d"]
+          imagePullPolicy: IfNotPresent
+ `
 )

--- a/tests/test_cases.go
+++ b/tests/test_cases.go
@@ -161,4 +161,8 @@ var testCases = []testing.InternalTest{
 		Name: "S8",
 		F:    federation.TestSingleClusterFedDiffCert,
 	},
+	testing.InternalTest{
+		Name: "S9",
+		F:    ossm.TestInitContainer,
+	},
 }


### PR DESCRIPTION
This case tests if the init container is not removed
when injecting the sidecar proxy.