### PR TITLE
Provide configuration via .env file for mesh namespace and smcp name

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The test cases include several changes for an OpenShift environment. Currently, 
 ## Testing Prerequisite
 
 1. User can access a running OpenShift cluster from command line.
-2. Service Mesh Control Plane (SMCP) has been installed on an OpenShift cluster. The SMCP is in namespace `istio-system` and the SMCP name is `basic`
+2. Service Mesh Control Plane (SMCP) has been installed on an OpenShift cluster. The `tests/.env` file is configured for the namespace where SMCP is located like `istio-system` and for the SMCP name, like `basic`. Then in all cases `source .env` has to be executed.
 3. An `oc` client has been installed. User has completed CLI login an OCP cluster as an admin user. Run `oc login -u [user] -p [token] --server=[OCP API server]`
 
 ## Testing
@@ -51,7 +51,7 @@ The test cases include several changes for an OpenShift environment. Currently, 
         $ export SAMPLEARCH=z
         ```
 
-- To run all the test cases: `cd tests; go test -timeout 3h -v`. It is required to use the `-timeout` flag. Otherwise, the go test will fall into panic after 10 minutes.
+- To run all the test cases: `cd tests; source .env; go test -timeout 3h -v`. It is required to use the `-timeout` flag. Otherwise, the go test will fall into panic after 10 minutes.
     ```
     $ cd tests
     $ go test -timeout 3h -v 2>&1 | tee >(${GOPATH}/bin/go-junit-report > results.xml) test.log

--- a/pkg/ossm/smcp_install.go
+++ b/pkg/ossm/smcp_install.go
@@ -23,12 +23,13 @@ import (
 )
 
 func installDefaultSMCP21() {
-	util.Log.Info("Create SMCP v2.1 in istio-system")
-	util.ShellMuteOutputError(`oc new-project istio-system`)
-	util.KubeApply("istio-system", smcpV21)
-	util.KubeApply("istio-system", smmr)
+	util.Log.Info("Create SMCP v2.1 in ", meshNamespace)
+	util.ShellMuteOutputError(`oc new-project %s`, meshNamespace)
+	util.Shell(`envsubst < %s > %s`, smcpV21_template, smcpV21)
+	util.KubeApply(meshNamespace, smcpV21)
+	util.KubeApply(meshNamespace, smmr)
 	util.Log.Info("Waiting for mesh installation to complete")
-	util.Shell(`oc wait --for condition=Ready -n %s smmr/default --timeout 300s`, "istio-system")
+	util.Shell(`oc wait --for condition=Ready -n %s smmr/default --timeout 300s`, meshNamespace)
 }
 
 func TestSMCPInstall(t *testing.T) {
@@ -36,108 +37,116 @@ func TestSMCPInstall(t *testing.T) {
 
 	t.Run("smcp_test_install_2.1", func(t *testing.T) {
 		defer util.RecoverPanic(t)
-		util.Log.Info("Create SMCP v2.1 in istio-system")
-		util.ShellMuteOutputError(`oc new-project istio-system`)
-		util.KubeApply("istio-system", smcpV21)
-		util.KubeApply("istio-system", smmr)
+		util.Log.Info("Create SMCP v2.1 in ", meshNamespace)
+		util.ShellMuteOutputError(`oc new-project %s`, meshNamespace)
+		util.Shell(`envsubst < %s > %s`, smcpV21_template, smcpV21)
+		util.KubeApply(meshNamespace, smcpV21)
+		util.KubeApply(meshNamespace, smmr)
 		util.Log.Info("Waiting for mesh installation to complete")
-		util.Shell(`oc wait --for condition=Ready -n %s smmr/default --timeout 300s`, "istio-system")
+		util.Shell(`oc wait --for condition=Ready -n %s smmr/default --timeout 300s`, meshNamespace)
 
 		util.Log.Info("Verify SMCP status and pods")
-		msg, _ := util.Shell(`oc get -n %s smcp/%s -o wide`, "istio-system", "basic")
+		msg, _ := util.Shell(`oc get -n %s smcp/%s -o wide`, meshNamespace, smcpName)
 		if !strings.Contains(msg, "ComponentsReady") {
 			util.Log.Error("SMCP not Ready")
 			t.Error("SMCP not Ready")
 		}
-		util.Shell(`oc get -n %s pods`, "istio-system")
+		util.Shell(`oc get -n %s pods`, meshNamespace)
 	})
 
 	t.Run("smcp_test_uninstall_2.1", func(t *testing.T) {
 		defer util.RecoverPanic(t)
-		util.Log.Info("Delete SMCP v2.1 in istio-system")
-		util.KubeDelete("istio-system", smmr)
-		util.KubeDelete("istio-system", smcpV21)
+		util.Log.Info("Delete SMCP v2.1 in ", meshNamespace)
+		util.KubeDelete(meshNamespace, smmr)
+		util.Shell(`envsubst < %s > %s`, smcpV21_template, smcpV21)
+		util.KubeDelete(meshNamespace, smcpV21)
 		time.Sleep(time.Duration(40) * time.Second)
 	})
 
 	t.Run("smcp_test_install_2.0", func(t *testing.T) {
 		defer util.RecoverPanic(t)
-		util.Log.Info("Create SMCP v2.0 in namespace istio-system")
-		util.ShellMuteOutputError(`oc new-project istio-system`)
-		util.KubeApply("istio-system", smcpV20)
-		util.KubeApply("istio-system", smmr)
+		util.Log.Info("Create SMCP v2.0 in namespace ", meshNamespace)
+		util.ShellMuteOutputError(`oc new-project %s`, meshNamespace)
+		util.Shell(`envsubst < %s > %s`, smcpV20_template, smcpV20)
+		util.KubeApply(meshNamespace, smcpV20)
+		util.KubeApply(meshNamespace, smmr)
 		util.Log.Info("Waiting for mesh installation to complete")
-		util.Shell(`oc wait --for condition=Ready -n %s smmr/default --timeout 300s`, "istio-system")
+		util.Shell(`oc wait --for condition=Ready -n %s smmr/default --timeout 300s`, meshNamespace)
 
 		util.Log.Info("Verify SMCP status and pods")
-		msg, _ := util.Shell(`oc get -n %s smcp/%s -o wide`, "istio-system", "basic")
+		msg, _ := util.Shell(`oc get -n %s smcp/%s -o wide`, meshNamespace, smcpName)
 		if !strings.Contains(msg, "ComponentsReady") {
 			util.Log.Error("SMCP not Ready")
 			t.Error("SMCP not Ready")
 		}
-		util.Shell(`oc get -n %s pods`, "istio-system")
+		util.Shell(`oc get -n %s pods`, meshNamespace)
 	})
 
 	t.Run("smcp_test_uninstall_2.0", func(t *testing.T) {
 		defer util.RecoverPanic(t)
-		util.Log.Info("Delete SMCP v2.0 in istio-system")
-		util.KubeDelete("istio-system", smmr)
-		util.KubeDelete("istio-system", smcpV20)
+		util.Log.Info("Delete SMCP v2.0 in ", meshNamespace)
+		util.KubeDelete(meshNamespace, smmr)
+		util.Shell(`envsubst < %s > %s`, smcpV20_template, smcpV20)
+		util.KubeDelete(meshNamespace, smcpV20)
 		time.Sleep(time.Duration(40) * time.Second)
 	})
 
 	t.Run("smcp_test_install_1.1", func(t *testing.T) {
 		defer util.RecoverPanic(t)
-		util.Log.Info("Create SMCP v1.1 in namespace istio-system")
-		util.ShellMuteOutputError(`oc new-project istio-system`)
-		util.KubeApply("istio-system", smcpV11)
-		util.KubeApply("istio-system", smmr)
+		util.Log.Info("Create SMCP v1.1 in namespace ", meshNamespace)
+		util.ShellMuteOutputError(`oc new-project %s`, meshNamespace)
+		util.Shell(`envsubst < %s > %s`, smcpV11_template, smcpV11)
+		util.KubeApply(meshNamespace, smcpV11)
+		util.KubeApply(meshNamespace, smmr)
 		util.Log.Info("Waiting for mesh installation to complete")
-		util.Shell(`oc wait --for condition=Ready -n %s smmr/default --timeout 300s`, "istio-system")
+		util.Shell(`oc wait --for condition=Ready -n %s smmr/default --timeout 300s`, meshNamespace)
 
 		util.Log.Info("Verify SMCP status and pods")
-		msg, _ := util.Shell(`oc get -n %s smcp/%s -o wide`, "istio-system", "basic")
+		msg, _ := util.Shell(`oc get -n %s smcp/%s -o wide`, meshNamespace, smcpName)
 		if !strings.Contains(msg, "ComponentsReady") {
 			util.Log.Error("SMCP not Ready")
 			t.Error("SMCP not Ready")
 		}
-		util.Shell(`oc get -n %s pods`, "istio-system")
+		util.Shell(`oc get -n %s pods`, meshNamespace)
 	})
 
 	t.Run("smcp_test_uninstall_1.1", func(t *testing.T) {
 		defer util.RecoverPanic(t)
-		util.Log.Info("Delete SMCP v1,1 in istio-system")
-		util.KubeDelete("istio-system", smmr)
-		util.KubeDelete("istio-system", smcpV11)
+		util.Log.Info("Delete SMCP v1,1 in ", meshNamespace)
+		util.KubeDelete(meshNamespace, smmr)
+		util.Shell(`envsubst < %s > %s`, smcpV11_template, smcpV11)
+		util.KubeDelete(meshNamespace, smcpV11)
 		time.Sleep(time.Duration(40) * time.Second)
 	})
 
 	t.Run("smcp_test_upgrade_2.0_to_2.1", func(t *testing.T) {
 		defer util.RecoverPanic(t)
 
-		util.Log.Info("Create SMCP v2.0 in namespace istio-system")
-		util.ShellMuteOutputError(`oc new-project istio-system`)
-		util.KubeApply("istio-system", smcpV20)
-		util.KubeApply("istio-system", smmr)
+		util.Log.Info("Create SMCP v2.0 in namespace ", meshNamespace)
+		util.ShellMuteOutputError(`oc new-project %s`, meshNamespace)
+		util.Shell(`envsubst < %s > %s`, smcpV20_template, smcpV20)
+		util.KubeApply(meshNamespace, smcpV20)
+		util.KubeApply(meshNamespace, smmr)
 		util.Log.Info("Waiting for mesh installation to complete")
-		util.Shell(`oc wait --for condition=Ready -n %s smmr/default --timeout 300s`, "istio-system")
+		util.Shell(`oc wait --for condition=Ready -n %s smmr/default --timeout 300s`, meshNamespace)
 
 		util.Log.Info("Verify SMCP status and pods")
-		util.Shell(`oc get -n %s smcp/%s -o wide`, "istio-system", "basic")
-		util.Shell(`oc get -n %s pods`, "istio-system")
+		util.Shell(`oc get -n %s smcp/%s -o wide`, meshNamespace, smcpName)
+		util.Shell(`oc get -n %s pods`, meshNamespace)
 
 		util.Log.Info("Upgrade SMCP to v2.1 in istio-system")
-		util.KubeApply("istio-system", smcpV21)
+		util.Shell(`envsubst < %s > %s`, smcpV21_template, smcpV21)
+		util.KubeApply(meshNamespace, smcpV21)
 		util.Log.Info("Waiting for mesh installation to complete")
 		time.Sleep(time.Duration(10) * time.Second)
-		util.Shell(`oc wait --for condition=Ready -n %s smmr/default --timeout 360s`, "istio-system")
+		util.Shell(`oc wait --for condition=Ready -n %s smmr/default --timeout 360s`, meshNamespace)
 
 		util.Log.Info("Verify SMCP status and pods")
-		msg, _ := util.Shell(`oc get -n %s smcp/%s -o wide`, "istio-system", "basic")
+		msg, _ := util.Shell(`oc get -n %s smcp/%s -o wide`, meshNamespace, smcpName)
 		if !strings.Contains(msg, "ComponentsReady") {
 			util.Log.Error("SMCP not Ready")
 			t.Error("SMCP not Ready")
 		}
-		util.Shell(`oc get -n %s pods`, "istio-system")
+		util.Shell(`oc get -n %s pods`, meshNamespace)
 	})
 }

--- a/pkg/ossm/sme_install.go
+++ b/pkg/ossm/sme_install.go
@@ -55,7 +55,7 @@ func TestExtensionInstall(t *testing.T) {
 
 	t.Run("Operator_test_sme_install", func(t *testing.T) {
 		defer util.RecoverPanic(t)
-		util.CheckPodRunning("istio-system", "app=wasm-cacher")
+		util.CheckPodRunning(meshNamespace, "app=wasm-cacher")
 
 		util.Log.Info("Creating ServiceMeshExtension")
 		util.KubeApplyContents("bookinfo", httpbinServiceMeshExtension)

--- a/pkg/ossm/yaml_vars.go
+++ b/pkg/ossm/yaml_vars.go
@@ -14,9 +14,24 @@
 
 package ossm
 
+import "os"
+
 var (
-	smcpV21 = "../templates/smcp-templates/v2.1/cr_2.1_default.yaml"
-	smcpV20 = "../templates/smcp-templates/v2.0/cr_2.0_default.yaml"
-	smcpV11 = "../templates/smcp-templates/v1.1/cr_1.1_default.yaml"
-	smmr    = "../templates/smmr-templates/smmr_default.yaml"
+	meshNamespace    string = getenv("MESHNAMESPACE", "istio-system")
+	smcpName         string = getenv("SMCPNAME", "basic")
+	smcpV21_template        = "../templates/smcp-templates/v2.1/cr_2.1_default_template.yaml"
+	smcpV20_template        = "../templates/smcp-templates/v2.0/cr_2.0_default_template.yaml"
+	smcpV11_template        = "../templates/smcp-templates/v1.1/cr_1.1_default_template.yaml"
+	smcpV21                 = "../templates/smcp-templates/v2.1/cr_2.1_default.yaml"
+	smcpV20                 = "../templates/smcp-templates/v2.0/cr_2.0_default.yaml"
+	smcpV11                 = "../templates/smcp-templates/v1.1/cr_1.1_default.yaml"
+	smmr                    = "../templates/smmr-templates/smmr_default.yaml"
 )
+
+func getenv(key, fallback string) string {
+	value := os.Getenv(key)
+	if len(value) == 0 {
+		return fallback
+	}
+	return value
+}

--- a/pkg/tasks/security/authentication/auth.go
+++ b/pkg/tasks/security/authentication/auth.go
@@ -26,15 +26,15 @@ import (
 
 func cleanupAuthPolicy() {
 	util.Log.Info("Cleanup")
-	util.KubeDeleteContents("istio-system", RequireTokenPathPolicy)
-	util.KubeDeleteContents("istio-system", RequireTokenPolicy)
-	util.KubeDeleteContents("istio-system", JWTAuthPolicy)
+	util.KubeDeleteContents(meshNamespace, RequireTokenPathPolicy)
+	util.KubeDeleteContents(meshNamespace, RequireTokenPolicy)
+	util.KubeDeleteContents(meshNamespace, JWTAuthPolicy)
 	util.KubeDeleteContents("foo", HttpbinGateway)
 	util.KubeDeleteContents("foo", OverwritePolicy)
 	util.KubeDeleteContents("bar", PortPolicy)
 	util.KubeDeleteContents("bar", WorkloadPolicyStrict)
 	util.KubeDeleteContents("foo", NamespacePolicyStrict)
-	util.KubeDeleteContents("istio-system", PeerAuthPolicyStrict)
+	util.KubeDeleteContents(meshNamespace, PeerAuthPolicyStrict)
 
 	sleep := examples.Sleep{"foo"}
 	httpbin := examples.Httpbin{"foo"}
@@ -113,7 +113,7 @@ func TestAuthPolicy(t *testing.T) {
 		defer util.RecoverPanic(t)
 
 		util.Log.Info("Globally enabling Istio mutual TLS in STRICT mode")
-		util.KubeApplyContents("istio-system", PeerAuthPolicyStrict)
+		util.KubeApplyContents(meshNamespace, PeerAuthPolicyStrict)
 		util.Log.Info("Waiting for rules to propagate. Sleep 30 seconds...")
 		time.Sleep(time.Duration(30) * time.Second)
 
@@ -132,7 +132,7 @@ func TestAuthPolicy(t *testing.T) {
 				util.Log.Infof("Response 000 as expected: %s", msg)
 			}
 		}
-		util.KubeDeleteContents("istio-system", PeerAuthPolicyStrict)
+		util.KubeDeleteContents(meshNamespace, PeerAuthPolicyStrict)
 		time.Sleep(time.Duration(30) * time.Second)
 	})
 
@@ -249,7 +249,7 @@ func TestAuthPolicy(t *testing.T) {
 		}
 
 		util.Log.Info("Apply a JWT policy")
-		util.KubeApplyContents("istio-system", JWTAuthPolicy)
+		util.KubeApplyContents(meshNamespace, JWTAuthPolicy)
 		time.Sleep(time.Duration(20) * time.Second)
 
 		util.Log.Info("Request without token returns 200. Request with an invalid token returns 401")
@@ -293,7 +293,7 @@ func TestAuthPolicy(t *testing.T) {
 		defer util.RecoverPanic(t)
 
 		util.Log.Info("Require a valid token")
-		util.KubeApplyContents("istio-system", RequireTokenPolicy)
+		util.KubeApplyContents(meshNamespace, RequireTokenPolicy)
 		time.Sleep(time.Duration(20) * time.Second)
 
 		msg, err := util.Shell(`curl %s/headers -s -o /dev/null -w "%%{http_code}\n"`, gatewayHTTP)
@@ -306,7 +306,7 @@ func TestAuthPolicy(t *testing.T) {
 		}
 
 		util.Log.Info("Require valid tokens per-path")
-		util.KubeApplyContents("istio-system", RequireTokenPathPolicy)
+		util.KubeApplyContents(meshNamespace, RequireTokenPathPolicy)
 		time.Sleep(time.Duration(20) * time.Second)
 
 		msg, err = util.Shell(`curl %s/headers -s -o /dev/null -w "%%{http_code}\n"`, gatewayHTTP)

--- a/pkg/tasks/security/authentication/mtls_migration.go
+++ b/pkg/tasks/security/authentication/mtls_migration.go
@@ -26,7 +26,7 @@ import (
 
 func cleanupMigration() {
 	util.Log.Info("Cleanup")
-	util.KubeDeleteContents("istio-system", MeshPolicyStrict)
+	util.KubeDeleteContents(meshNamespace, MeshPolicyStrict)
 	util.KubeDeleteContents("foo", NamespacePolicyStrict)
 	sleep := examples.Sleep{"foo"}
 	httpbin := examples.Httpbin{"foo"}
@@ -112,7 +112,7 @@ func TestMigration(t *testing.T) {
 		defer util.RecoverPanic(t)
 
 		util.Log.Info("Lock down to mutual TLS for the entire mesh")
-		util.KubeApplyContents("istio-system", MeshPolicyStrict)
+		util.KubeApplyContents(meshNamespace, MeshPolicyStrict)
 		time.Sleep(time.Duration(30) * time.Second)
 
 		for _, from := range []string{"legacy"} {

--- a/pkg/tasks/security/authentication/yaml_configs.go
+++ b/pkg/tasks/security/authentication/yaml_configs.go
@@ -14,13 +14,13 @@
 
 package authentication
 
-const (
+var (
 	PeerAuthPolicyStrict = `
 apiVersion: "security.istio.io/v1beta1"
 kind: "PeerAuthentication"
 metadata:
   name: "default"
-  namespace: "istio-system"
+  namespace: "` + meshNamespace + `"
 spec:
   mtls:
     mode: STRICT
@@ -157,7 +157,7 @@ apiVersion: "security.istio.io/v1beta1"
 kind: "RequestAuthentication"
 metadata:
   name: "jwt-example"
-  namespace: istio-system
+  namespace: ` + meshNamespace + `
 spec:
   selector:
     matchLabels:
@@ -173,7 +173,7 @@ apiVersion: "security.istio.io/v1beta1"
 kind: "AuthorizationPolicy"
 metadata:
   name: "frontend-ingress"
-  namespace: istio-system
+  namespace: ` + meshNamespace + `
 spec:
   selector:
     matchLabels:
@@ -190,7 +190,7 @@ apiVersion: "security.istio.io/v1beta1"
 kind: "AuthorizationPolicy"
 metadata:
   name: "frontend-ingress"
-  namespace: istio-system
+  namespace: ` + meshNamespace + `
 spec:
   selector:
     matchLabels:
@@ -210,7 +210,7 @@ apiVersion: "security.istio.io/v1beta1"
 kind: "PeerAuthentication"
 metadata:
   name: "default"
-  namespace: "istio-system"
+  namespace: "` + meshNamespace + `"
 spec:
   mtls:
     mode: STRICT

--- a/pkg/tasks/security/authentication/yaml_vars.go
+++ b/pkg/tasks/security/authentication/yaml_vars.go
@@ -15,9 +15,21 @@
 package authentication
 
 import (
+	"os"
+
 	"github.com/maistra/maistra-test-tool/pkg/util"
 )
 
+func getenv(key, fallback string) string {
+	value := os.Getenv(key)
+	if len(value) == 0 {
+		return fallback
+	}
+	return value
+}
+
 var (
-	gatewayHTTP, _ = util.ShellSilent(`kubectl get routes -n %s istio-ingressgateway -o jsonpath='{.spec.host}'`, "istio-system")
+	meshNamespace  string = getenv("MESHNAMESPACE", "istio-system")
+	smcpName       string = getenv("SMCPNAME", "basic")
+	gatewayHTTP, _        = util.ShellSilent(`kubectl get routes -n %s istio-ingressgateway -o jsonpath='{.spec.host}'`, meshNamespace)
 )

--- a/pkg/tasks/security/authorization/http.go
+++ b/pkg/tasks/security/authorization/http.go
@@ -35,8 +35,8 @@ func cleanupAuthorHTTP() {
 	time.Sleep(time.Duration(20) * time.Second)
 	bookinfo := examples.Bookinfo{"bookinfo"}
 	bookinfo.Uninstall()
-	util.Shell(`kubectl patch -n istio-system smcp/basic --type merge -p '{"spec":{"security":{"dataPlane":{"mtls":false},"controlPlane":{"mtls":false}}}}'`)
-	util.Shell(`oc -n istio-system wait --for condition=Ready smcp/basic --timeout 180s`)
+	util.Shell(`kubectl patch -n %s smcp/%s --type merge -p '{"spec":{"security":{"dataPlane":{"mtls":false},"controlPlane":{"mtls":false}}}}'`, meshNamespace, smcpName)
+	util.Shell(`oc -n %s wait --for condition=Ready smcp/%s --timeout 180s`, meshNamespace, smcpName)
 	time.Sleep(time.Duration(20) * time.Second)
 }
 
@@ -46,8 +46,8 @@ func TestAuthorHTTP(t *testing.T) {
 
 	util.Log.Info("Authorization for HTTP traffic")
 	util.Log.Info("Enable Control Plane MTLS")
-	util.Shell(`kubectl patch -n istio-system smcp/basic --type merge -p '{"spec":{"security":{"dataPlane":{"mtls":true},"controlPlane":{"mtls":true}}}}'`)
-	util.Shell(`oc -n istio-system wait --for condition=Ready smcp/basic --timeout 180s`)
+	util.Shell(`kubectl patch -n %s smcp/%s --type merge -p '{"spec":{"security":{"dataPlane":{"mtls":true},"controlPlane":{"mtls":true}}}}'`, meshNamespace, smcpName)
+	util.Shell(`oc -n %s wait --for condition=Ready smcp/%s --timeout 180s`, meshNamespace, smcpName)
 
 	bookinfo := examples.Bookinfo{"bookinfo"}
 	bookinfo.Install(true)

--- a/pkg/tasks/security/authorization/yaml.vars.go
+++ b/pkg/tasks/security/authorization/yaml.vars.go
@@ -15,9 +15,21 @@
 package authorizaton
 
 import (
+	"os"
+
 	"github.com/maistra/maistra-test-tool/pkg/util"
 )
 
 var (
-	gatewayHTTP, _ = util.ShellSilent(`kubectl get routes -n %s istio-ingressgateway -o jsonpath='{.spec.host}'`, "istio-system")
+	meshNamespace  string = getenv("MESHNAMESPACE", "istio-system")
+	smcpName       string = getenv("SMCPNAME", "basic")
+	gatewayHTTP, _        = util.ShellSilent(`kubectl get routes -n %s istio-ingressgateway -o jsonpath='{.spec.host}'`, meshNamespace)
 )
+
+func getenv(key, fallback string) string {
+	value := os.Getenv(key)
+	if len(value) == 0 {
+		return fallback
+	}
+	return value
+}

--- a/pkg/tasks/security/certificate/external_ca.go
+++ b/pkg/tasks/security/certificate/external_ca.go
@@ -31,18 +31,10 @@ func cleanupExternalCert() {
 	bookinfo := examples.Bookinfo{Namespace: "bookinfo"}
 	bookinfo.Uninstall()
 
-	util.Shell(`kubectl -n istio-system delete secret cacerts`)
-	util.Shell(`kubectl -n istio-system patch smcp/basic --type=json -p='[{"op": "remove", "path": "/spec/security/certificateAuthority"}, {"op": "remove", "path": "/spec/security/dataPlane"}]'`)
-	util.Shell(`oc -n istio-system wait --for condition=Ready smcp/basic --timeout 180s`)
+	util.Shell(`kubectl -n %s delete secret cacerts`, meshNamespace)
+	util.Shell(`kubectl -n %s patch smcp/%s --type=json -p='[{"op": "remove", "path": "/spec/security/certificateAuthority"}, {"op": "remove", "path": "/spec/security/dataPlane"}]'`, meshNamespace, smcpName)
+	util.Shell(`oc -n %s wait --for condition=Ready smcp/%s --timeout 180s`, meshNamespace, smcpName)
 	time.Sleep(time.Duration(60) * time.Second)
-}
-
-func getenv(key, fallback string) string {
-	value := os.Getenv(key)
-	if len(value) == 0 {
-		return fallback
-	}
-	return value
 }
 
 func TestExternalCert(t *testing.T) {
@@ -56,10 +48,10 @@ func TestExternalCert(t *testing.T) {
 
 		util.Log.Info("Adding an external CA")
 		util.Shell(`kubectl create -n %s secret generic cacerts --from-file=%s --from-file=%s --from-file=%s --from-file=%s`,
-			"istio-system", sampleCACert, sampleCAKey, sampleCARoot, sampleCAChain)
+			meshNamespace, sampleCACert, sampleCAKey, sampleCARoot, sampleCAChain)
 
-		util.Shell(`kubectl -n istio-system patch smcp/basic --type=merge --patch="%s"`, CertSMCPPath)
-		util.Shell(`oc -n istio-system wait --for condition=Ready smcp/basic --timeout 180s`)
+		util.Shell(`kubectl -n %s patch smcp/%s --type=merge --patch="%s"`, meshNamespace, smcpName, CertSMCPPath)
+		util.Shell(`oc -n %s wait --for condition=Ready smcp/%s --timeout 180s`, meshNamespace, smcpName)
 		time.Sleep(time.Duration(60) * time.Second)
 
 		bookinfo := examples.Bookinfo{Namespace: "bookinfo"}
@@ -72,8 +64,8 @@ func TestExternalCert(t *testing.T) {
 		util.Inspect(err, "Failed to create temp dir", "", t)
 		defer os.RemoveAll(tmpDir)
 
-		if getenv("SAMPLEARCH", "x86") == "p"  || getenv("SAMPLEARCH", "x86") == "z" {
-			gatewayHTTP, _ := util.ShellSilent(`kubectl get routes -n %s istio-ingressgateway -o jsonpath='{.spec.host}'`, "istio-system")
+		if getenv("SAMPLEARCH", "x86") == "p" || getenv("SAMPLEARCH", "x86") == "z" {
+			gatewayHTTP, _ := util.ShellSilent(`kubectl get routes -n %s istio-ingressgateway -o jsonpath='{.spec.host}'`, meshNamespace)
 			productpageURL := fmt.Sprintf("http://%s/productpage", gatewayHTTP)
 			resp, _, err := util.GetHTTPResponse(productpageURL, nil)
 			util.Inspect(err, "Failed to get HTTP Response", "", t)

--- a/pkg/tasks/security/certificate/yaml_vars.go
+++ b/pkg/tasks/security/certificate/yaml_vars.go
@@ -14,9 +14,24 @@
 
 package certificate
 
+import "os"
+
 const (
 	sampleCACert  = "../sampleCerts/ca-cert.pem"
 	sampleCAKey   = "../sampleCerts/ca-key.pem"
 	sampleCARoot  = "../sampleCerts/root-cert.pem"
 	sampleCAChain = "../sampleCerts/cert-chain.pem"
 )
+
+var (
+	meshNamespace string = getenv("MESHNAMESPACE", "istio-system")
+	smcpName      string = getenv("SMCPNAME", "basic")
+)
+
+func getenv(key, fallback string) string {
+	value := os.Getenv(key)
+	if len(value) == 0 {
+		return fallback
+	}
+	return value
+}

--- a/pkg/tasks/traffic/egress/egress_gateways_tls_sds.go
+++ b/pkg/tasks/traffic/egress/egress_gateways_tls_sds.go
@@ -26,10 +26,10 @@ import (
 
 func cleanupTLSOriginationSDS() {
 	util.Log.Info("Cleanup")
-	util.KubeDeleteContents("istio-system", OriginateSDS)
+	util.KubeDeleteContents(meshNamespace, OriginateSDS)
 	util.KubeDeleteContents("bookinfo", EgressGatewaySDS)
-	util.Shell(`kubectl delete -n %s secret client-credential`, "istio-system")
-	util.Shell(`kubectl delete -n %s secret client-credential-cacert`, "istio-system")
+	util.Shell(`kubectl delete -n %s secret client-credential`, meshNamespace)
+	util.Shell(`kubectl delete -n %s secret client-credential-cacert`, meshNamespace)
 	sleep := examples.Sleep{"bookinfo"}
 	nginx := examples.Nginx{"mesh-external"}
 	sleep.Uninstall()
@@ -48,7 +48,7 @@ func TestTLSOriginationSDS(t *testing.T) {
 
 	nginx := examples.Nginx{"mesh-external"}
 	nginx.Install("../testdata/examples/x86/nginx/nginx_mesh_external.conf")
-	util.Shell(`kubectl create -n %s secret generic client-credential-cacert --from-file=%s`, "istio-system", nginxServerCACert)
+	util.Shell(`kubectl create -n %s secret generic client-credential-cacert --from-file=%s`, meshNamespace, nginxServerCACert)
 
 	t.Run("TrafficManagement_egress_configure_tls_origination", func(t *testing.T) {
 		defer util.RecoverPanic(t)
@@ -56,7 +56,7 @@ func TestTLSOriginationSDS(t *testing.T) {
 		util.Log.Info("Configure simple TLS origination for egress traffic")
 		util.KubeApplyContents("bookinfo", EgressGatewaySDS)
 		time.Sleep(time.Duration(20) * time.Second)
-		util.KubeApplyContents("istio-system", OriginateSDS)
+		util.KubeApplyContents(meshNamespace, OriginateSDS)
 		time.Sleep(time.Duration(10) * time.Second)
 
 		util.Log.Info("Verify NGINX server")
@@ -80,7 +80,7 @@ func TestTLSOriginationSDS(t *testing.T) {
 		nginx := examples.Nginx{"mesh-external"}
 		nginx.Install("../testdata/examples/x86/nginx/nginx_mesh_external_ssl.conf")
 		util.Shell(`kubectl create -n %s secret generic client-credential --from-file=tls.key=%s --from-file=tls.crt=%s --from-file=ca.crt=%s`,
-			"istio-system", nginxClientCertKey, nginxClientCert, nginxServerCACert)
+			meshNamespace, nginxClientCertKey, nginxClientCert, nginxServerCACert)
 
 	})
 }

--- a/pkg/tasks/traffic/egress/yaml_configs.go
+++ b/pkg/tasks/traffic/egress/yaml_configs.go
@@ -14,7 +14,7 @@
 
 package egress
 
-const (
+var (
 	httbinextServiceEntry = `
 apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
@@ -149,7 +149,7 @@ kind: DestinationRule
 metadata:
   name: egressgateway-for-cnn
 spec:
-  host: istio-egressgateway.istio-system.svc.cluster.local
+  host: istio-egressgateway.` + meshNamespace + `.svc.cluster.local
   subsets:
   - name: cnn
 ---
@@ -170,7 +170,7 @@ spec:
       port: 80
     route:
     - destination:
-        host: istio-egressgateway.istio-system.svc.cluster.local
+        host: istio-egressgateway.` + meshNamespace + `.svc.cluster.local
         subset: cnn
         port:
           number: 80
@@ -210,7 +210,7 @@ kind: DestinationRule
 metadata:
   name: egressgateway-for-cnn
 spec:
-  host: istio-egressgateway.istio-system.svc.cluster.local
+  host: istio-egressgateway.` + meshNamespace + `.svc.cluster.local
   subsets:
   - name: cnn
 ---
@@ -233,7 +233,7 @@ spec:
       - edition.cnn.com
     route:
     - destination:
-        host: istio-egressgateway.istio-system.svc.cluster.local
+        host: istio-egressgateway.` + meshNamespace + `.svc.cluster.local
         subset: cnn
         port:
           number: 443
@@ -274,7 +274,7 @@ kind: DestinationRule
 metadata:
   name: egressgateway-for-cnn
 spec:
-  host: istio-egressgateway.istio-system.svc.cluster.local
+  host: istio-egressgateway.` + meshNamespace + `.svc.cluster.local
   subsets:
   - name: cnn
     trafficPolicy:
@@ -304,7 +304,7 @@ spec:
       port: 80
     route:
     - destination:
-        host: istio-egressgateway.istio-system.svc.cluster.local
+        host: istio-egressgateway.` + meshNamespace + `.svc.cluster.local
         subset: cnn
         port:
           number: 80
@@ -359,7 +359,7 @@ kind: DestinationRule
 metadata:
   name: egressgateway-for-nginx
 spec:
-  host: istio-egressgateway.istio-system.svc.cluster.local
+  host: istio-egressgateway.` + meshNamespace + `.svc.cluster.local
   subsets:
   - name: nginx
     trafficPolicy:
@@ -389,7 +389,7 @@ spec:
       port: 80
     route:
     - destination:
-        host: istio-egressgateway.istio-system.svc.cluster.local
+        host: istio-egressgateway.` + meshNamespace + `.svc.cluster.local
         subset: nginx
         port:
           number: 443
@@ -451,7 +451,7 @@ kind: DestinationRule
 metadata:
   name: egressgateway-for-nginx
 spec:
-  host: istio-egressgateway.istio-system.svc.cluster.local
+  host: istio-egressgateway.` + meshNamespace + `.svc.cluster.local
   subsets:
   - name: nginx
     trafficPolicy:
@@ -481,7 +481,7 @@ spec:
       port: 80
     route:
     - destination:
-        host: istio-egressgateway.istio-system.svc.cluster.local
+        host: istio-egressgateway.` + meshNamespace + `.svc.cluster.local
         subset: nginx
         port:
           number: 443
@@ -554,7 +554,7 @@ kind: DestinationRule
 metadata:
   name: egressgateway-for-wikipedia
 spec:
-  host: istio-egressgateway.istio-system.svc.cluster.local
+  host: istio-egressgateway.` + meshNamespace + `.svc.cluster.local
   subsets:
     - name: wikipedia
 ---
@@ -577,7 +577,7 @@ spec:
       - "*.wikipedia.org"
     route:
     - destination:
-        host: istio-egressgateway.istio-system.svc.cluster.local
+        host: istio-egressgateway.` + meshNamespace + `.svc.cluster.local
         subset: wikipedia
         port:
           number: 443

--- a/pkg/tasks/traffic/egress/yaml_vars.go
+++ b/pkg/tasks/traffic/egress/yaml_vars.go
@@ -14,8 +14,22 @@
 
 package egress
 
+import "os"
+
 const (
 	nginxClientCertKey = "../sampleCerts/nginx.example.com/nginx-client.example.com.key"
 	nginxClientCert    = "../sampleCerts/nginx.example.com/nginx-client.example.com.crt"
 	nginxServerCACert  = "../sampleCerts/nginx.example.com/example.com.crt"
 )
+
+var (
+	meshNamespace string = getenv("MESHNAMESPACE", "istio-system")
+)
+
+func getenv(key, fallback string) string {
+	value := os.Getenv(key)
+	if len(value) == 0 {
+		return fallback
+	}
+	return value
+}

--- a/pkg/tasks/traffic/ingress/secure_gateways.go
+++ b/pkg/tasks/traffic/ingress/secure_gateways.go
@@ -16,7 +16,6 @@ package ingress
 
 import (
 	"io/ioutil"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -36,14 +35,6 @@ func cleanupSecureGateways() {
 	util.KubeDeleteContents("bookinfo", helloworldv1)
 	httpbin.Uninstall()
 	time.Sleep(time.Duration(20) * time.Second)
-}
-
-func getenv(key, fallback string) string {
-	value := os.Getenv(key)
-	if len(value) == 0 {
-		return fallback
-	}
-	return value
 }
 
 func TestSecureGateways(t *testing.T) {

--- a/pkg/tasks/traffic/ingress/yaml_vars.go
+++ b/pkg/tasks/traffic/ingress/yaml_vars.go
@@ -15,6 +15,8 @@
 package ingress
 
 import (
+	"os"
+
 	"github.com/maistra/maistra-test-tool/pkg/util"
 )
 
@@ -32,14 +34,22 @@ const (
 	nginxServerCert    = "../sampleCerts/nginx.example.com/nginx.example.com.crt"
 	nginxServerCACert  = "../sampleCerts/nginx.example.com/example.com.crt"
 
-	meshNamespace = "istio-system"
-	smcpName      = "basic"
-	testUsername  = "jason"
+	testUsername = "jason"
 )
 
 var (
 	// OCP4.x
-	gatewayHTTP, _       = util.ShellSilent(`kubectl get routes -n %s istio-ingressgateway -o jsonpath='{.spec.host}'`, meshNamespace)
-	ingressHTTPPort, _   = util.ShellSilent(`kubectl -n %s get service %s -o jsonpath='{.spec.ports[?(@.name=="http2")].port}'`, meshNamespace, "istio-ingressgateway")
-	secureIngressPort, _ = util.ShellSilent(`kubectl -n %s get service %s -o jsonpath='{.spec.ports[?(@.name=="https")].port}'`, meshNamespace, "istio-ingressgateway")
+	meshNamespace        string = getenv("MESHNAMESPACE", "istio-system")
+	smcpName             string = getenv("SMCPNAME", "basic")
+	gatewayHTTP, _              = util.ShellSilent(`kubectl get routes -n %s istio-ingressgateway -o jsonpath='{.spec.host}'`, meshNamespace)
+	ingressHTTPPort, _          = util.ShellSilent(`kubectl -n %s get service %s -o jsonpath='{.spec.ports[?(@.name=="http2")].port}'`, meshNamespace, "istio-ingressgateway")
+	secureIngressPort, _        = util.ShellSilent(`kubectl -n %s get service %s -o jsonpath='{.spec.ports[?(@.name=="https")].port}'`, meshNamespace, "istio-ingressgateway")
 )
+
+func getenv(key, fallback string) string {
+	value := os.Getenv(key)
+	if len(value) == 0 {
+		return fallback
+	}
+	return value
+}

--- a/pkg/tasks/traffic/yaml_vars.go
+++ b/pkg/tasks/traffic/yaml_vars.go
@@ -15,6 +15,8 @@
 package traffic
 
 import (
+	"os"
+
 	"github.com/maistra/maistra-test-tool/pkg/util"
 )
 
@@ -30,14 +32,22 @@ const (
 	echoAllv1Yaml = "../testdata/examples/x86/tcp-echo/tcp-echo-all-v1.yaml"
 	echo20v2Yaml  = "../testdata/examples/x86/tcp-echo/tcp-echo-20-v2.yaml"
 
-	meshNamespace = "istio-system"
-	smcpName      = "basic"
-	testUsername  = "jason"
+	testUsername = "jason"
 )
 
 var (
 	// OCP4.x
-	gatewayHTTP, _       = util.ShellSilent(`kubectl get routes -n %s istio-ingressgateway -o jsonpath='{.spec.host}'`, meshNamespace)
-	ingressHTTPPort, _   = util.ShellSilent(`kubectl -n %s get service %s -o jsonpath='{.spec.ports[?(@.name=="http2")].port}'`, meshNamespace, "istio-ingressgateway")
-	secureIngressPort, _ = util.ShellSilent(`kubectl -n %s get service %s -o jsonpath='{.spec.ports[?(@.name=="https")].port}'`, meshNamespace, "istio-ingressgateway")
+	meshNamespace        string = getenv("MESHNAMESPACE", "istio-system")
+	smcpName             string = getenv("SMCPNAME", "basic")
+	gatewayHTTP, _              = util.ShellSilent(`kubectl get routes -n %s istio-ingressgateway -o jsonpath='{.spec.host}'`, meshNamespace)
+	ingressHTTPPort, _          = util.ShellSilent(`kubectl -n %s get service %s -o jsonpath='{.spec.ports[?(@.name=="http2")].port}'`, meshNamespace, "istio-ingressgateway")
+	secureIngressPort, _        = util.ShellSilent(`kubectl -n %s get service %s -o jsonpath='{.spec.ports[?(@.name=="https")].port}'`, meshNamespace, "istio-ingressgateway")
 )
+
+func getenv(key, fallback string) string {
+	value := os.Getenv(key)
+	if len(value) == 0 {
+		return fallback
+	}
+	return value
+}

--- a/templates/smcp-templates/v1.1/cr_1.1_default_template.yaml
+++ b/templates/smcp-templates/v1.1/cr_1.1_default_template.yaml
@@ -1,19 +1,20 @@
 apiVersion: maistra.io/v2
 kind: ServiceMeshControlPlane
 metadata:
-  name: basic
-  namespace: istio-system
+  name: ${SMCPNAME}
 spec:
   version: v1.1
   tracing:
     type: Jaeger
     sampling: 10000
   addons:
+    grafana:
+      enabled: true
     jaeger:
       install:
         storage:
           type: Memory
     kiali:
       enabled: true
-    grafana:
+    prometheus:
       enabled: true

--- a/templates/smcp-templates/v2.0/cr_2.0_default_template.yaml
+++ b/templates/smcp-templates/v2.0/cr_2.0_default_template.yaml
@@ -1,19 +1,25 @@
 apiVersion: maistra.io/v2
 kind: ServiceMeshControlPlane
 metadata:
-  name: basic
-  namespace: istio-system
+  name: ${SMCPNAME}
 spec:
-  version: v1.1
+  version: v2.0
   tracing:
     type: Jaeger
     sampling: 10000
+  policy:
+    type: Istiod
   addons:
+    grafana:
+      enabled: true
     jaeger:
       install:
         storage:
           type: Memory
     kiali:
       enabled: true
-    grafana:
+    prometheus:
       enabled: true
+  
+  telemetry:
+    type: Istiod

--- a/templates/smcp-templates/v2.1/cr_2.1_default_template.yaml
+++ b/templates/smcp-templates/v2.1/cr_2.1_default_template.yaml
@@ -1,12 +1,12 @@
 apiVersion: maistra.io/v2
 kind: ServiceMeshControlPlane
 metadata:
-  namespace: istio-system
-  name: basic
+  name: ${SMCPNAME}
 spec:
+  version: v2.1
   tracing:
-    sampling: 10000
     type: Jaeger
+    sampling: 10000
   policy:
     type: Istiod
   addons:
@@ -20,6 +20,6 @@ spec:
       enabled: true
     prometheus:
       enabled: true
-  version: v2.0
+  
   telemetry:
     type: Istiod

--- a/templates/smm-templates/smm_default_template.yaml
+++ b/templates/smm-templates/smm_default_template.yaml
@@ -4,5 +4,5 @@ metadata:
   name: default
 spec:
   controlPlaneRef:
-    namespace: istio-system
-    name: basic
+    namespace: ${MESHNAMESPACE}
+    name: ${SMCPNAME}

--- a/testdata/examples/p/ossm/cr_1.1_default_template.yaml
+++ b/testdata/examples/p/ossm/cr_1.1_default_template.yaml
@@ -1,0 +1,19 @@
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+metadata:
+  name: ${SMCPNAME}
+  namespace: ${MESHNAMESPACE}
+spec:
+  version: v1.1
+  tracing:
+    type: Jaeger
+    sampling: 10000
+  addons:
+    jaeger:
+      install:
+        storage:
+          type: Memory
+    kiali:
+      enabled: true
+    grafana:
+      enabled: true

--- a/testdata/examples/p/ossm/cr_2.0_default_template.yaml
+++ b/testdata/examples/p/ossm/cr_2.0_default_template.yaml
@@ -1,8 +1,8 @@
 apiVersion: maistra.io/v2
 kind: ServiceMeshControlPlane
 metadata:
-  namespace: istio-system
-  name: basic
+  namespace: ${MESHNAMESPACE}
+  name: ${SMCPNAME}
 spec:
   tracing:
     sampling: 10000

--- a/testdata/examples/p/ossm/cr_2.1_default_template.yaml
+++ b/testdata/examples/p/ossm/cr_2.1_default_template.yaml
@@ -1,8 +1,8 @@
 apiVersion: maistra.io/v2
 kind: ServiceMeshControlPlane
 metadata:
-  namespace: istio-system
-  name: basic
+  namespace: ${MESHNAMESPACE}
+  name: ${SMCPNAME}
 spec:
   tracing:
     sampling: 10000

--- a/testdata/examples/x86/ossm/cr_1.1_default_template.yaml
+++ b/testdata/examples/x86/ossm/cr_1.1_default_template.yaml
@@ -1,0 +1,19 @@
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+metadata:
+  name: ${SMCPNAME}
+  namespace: ${MESHNAMESPACE}
+spec:
+  version: v1.1
+  tracing:
+    type: Jaeger
+    sampling: 10000
+  addons:
+    jaeger:
+      install:
+        storage:
+          type: Memory
+    kiali:
+      enabled: true
+    grafana:
+      enabled: true

--- a/testdata/examples/x86/ossm/cr_2.0_default_template.yaml
+++ b/testdata/examples/x86/ossm/cr_2.0_default_template.yaml
@@ -1,8 +1,8 @@
 apiVersion: maistra.io/v2
 kind: ServiceMeshControlPlane
 metadata:
-  namespace: istio-system
-  name: basic
+  namespace: ${MESHNAMESPACE}
+  name: ${SMCPNAME}
 spec:
   tracing:
     sampling: 10000

--- a/testdata/examples/x86/ossm/cr_2.1_default_template.yaml
+++ b/testdata/examples/x86/ossm/cr_2.1_default_template.yaml
@@ -1,8 +1,8 @@
 apiVersion: maistra.io/v2
 kind: ServiceMeshControlPlane
 metadata:
-  namespace: istio-system
-  name: basic
+  namespace: ${MESHNAMESPACE}
+  name: ${SMCPNAME}
 spec:
   tracing:
     sampling: 10000

--- a/testdata/examples/z/ossm/cr_1.1_default_template.yaml
+++ b/testdata/examples/z/ossm/cr_1.1_default_template.yaml
@@ -1,0 +1,19 @@
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+metadata:
+  name: ${SMCPNAME}
+  namespace: ${MESHNAMESPACE}
+spec:
+  version: v1.1
+  tracing:
+    type: Jaeger
+    sampling: 10000
+  addons:
+    jaeger:
+      install:
+        storage:
+          type: Memory
+    kiali:
+      enabled: true
+    grafana:
+      enabled: true

--- a/testdata/examples/z/ossm/cr_2.0_default_template.yaml
+++ b/testdata/examples/z/ossm/cr_2.0_default_template.yaml
@@ -1,8 +1,8 @@
 apiVersion: maistra.io/v2
 kind: ServiceMeshControlPlane
 metadata:
-  namespace: istio-system
-  name: basic
+  namespace: ${MESHNAMESPACE}
+  name: ${SMCPNAME}
 spec:
   tracing:
     sampling: 10000
@@ -20,6 +20,6 @@ spec:
       enabled: true
     prometheus:
       enabled: true
-  version: v2.1
+  version: v2.0
   telemetry:
     type: Istiod

--- a/testdata/examples/z/ossm/cr_2.1_default_template.yaml
+++ b/testdata/examples/z/ossm/cr_2.1_default_template.yaml
@@ -1,19 +1,25 @@
 apiVersion: maistra.io/v2
 kind: ServiceMeshControlPlane
 metadata:
-  name: basic
-  namespace: istio-system
+  namespace: ${MESHNAMESPACE}
+  name: ${SMCPNAME}
 spec:
-  version: v1.1
   tracing:
-    type: Jaeger
     sampling: 10000
+    type: Jaeger
+  policy:
+    type: Istiod
   addons:
+    grafana:
+      enabled: true
     jaeger:
       install:
         storage:
           type: Memory
     kiali:
       enabled: true
-    grafana:
+    prometheus:
       enabled: true
+  version: v2.1
+  telemetry:
+    type: Istiod

--- a/testdata/resources/yaml/ratelimit-envoyfilter_template.yaml
+++ b/testdata/resources/yaml/ratelimit-envoyfilter_template.yaml
@@ -1,0 +1,87 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: filter-ratelimit
+spec:
+  workloadSelector:
+    # select by label in the same namespace
+    labels:
+      istio: ingressgateway
+  configPatches:
+    # The Envoy config you want to modify
+    - applyTo: HTTP_FILTER
+      match:
+        context: GATEWAY
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.filters.network.http_connection_manager"
+              subFilter:
+                name: "envoy.filters.http.router"
+      patch:
+        operation: INSERT_BEFORE
+        # Adds the Envoy Rate Limit Filter in HTTP filter chain.
+        value:
+          name: envoy.filters.http.ratelimit
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimit
+            # domain can be anything! Match it to the ratelimter service config
+            domain: productpage-ratelimit
+            failure_mode_deny: true
+            timeout: 10s
+            rate_limit_service:
+              grpc_service:
+                envoy_grpc:
+                  cluster_name: rate_limit_cluster
+              transport_api_version: V3
+    - applyTo: CLUSTER
+      match:
+        cluster:
+          service: rls-basic.${MESHNAMESPACE}.svc.cluster.local
+      patch:
+        operation: ADD
+        # Adds the rate limit service cluster for rate limit service defined in step 1.
+        value:
+          name: rate_limit_cluster
+          type: STRICT_DNS
+          connect_timeout: 10s
+          lb_policy: ROUND_ROBIN
+          http2_protocol_options: {}
+          load_assignment:
+            cluster_name: rate_limit_cluster
+            endpoints:
+            - lb_endpoints:
+              - endpoint:
+                  address:
+                     socket_address:
+                      address: rls-basic.${MESHNAMESPACE}.svc.cluster.local
+                      port_value: 8081
+
+---
+
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: filter-ratelimit-svc
+spec:
+  workloadSelector:
+    labels:
+      istio: ingressgateway
+  configPatches:
+    - applyTo: VIRTUAL_HOST
+      match:
+        context: GATEWAY
+        routeConfiguration:
+          vhost:
+            name: ""
+            route:
+              action: ANY
+      patch:
+        operation: MERGE
+        # Applies the rate limit rules.
+        value:
+          rate_limits:
+            - actions: # any actions in here
+              - request_headers:
+                  header_name: ":path"
+                  descriptor_key: "PATH"

--- a/tests/.env
+++ b/tests/.env
@@ -1,0 +1,2 @@
+export MESHNAMESPACE=istio-system
+export SMCPNAME=basic

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -21,9 +21,19 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util"
 )
 
+var meshNamespace string = getenv("MESHNAMESPACE", "istio-system")
+
 var (
 	SMMR = "../templates/smmr-templates/smmr_default.yaml"
 )
+
+func getenv(key, fallback string) string {
+	value := os.Getenv(key)
+	if len(value) == 0 {
+		return fallback
+	}
+	return value
+}
 
 func setupNamespaces() {
 	util.ShellSilent(`oc new-project bookinfo`)
@@ -31,8 +41,8 @@ func setupNamespaces() {
 	util.ShellSilent(`oc new-project bar`)
 	util.ShellSilent(`oc new-project legacy`)
 	util.ShellSilent(`oc new-project mesh-external`)
-	util.ShellSilent(`oc apply -n istio-system -f %s`, SMMR)
-	util.ShellSilent(`oc wait --for condition=Ready -n %s smmr/default --timeout 180s`, "istio-system")
+	util.ShellSilent(`oc apply -n %s -f %s`, meshNamespace, SMMR)
+	util.ShellSilent(`oc wait --for condition=Ready -n %s smmr/default --timeout 180s`, meshNamespace)
 }
 
 func matchString(a, b string) (bool, error) {


### PR DESCRIPTION
Majority of the changes would provide ability for dynamic configuration for mesh namespace and smcp name.
There is one small fix also at rate limiting cleanup, removing only specific part of techpreview belongs to ratelimiting.