### PR TITLE
Disable T25 test case for interop testing

### DIFF
--- a/pkg/ossm/sme_install.go
+++ b/pkg/ossm/sme_install.go
@@ -43,6 +43,12 @@ func cleanUpTestExtensionInstall() {
 }
 
 func TestExtensionInstall(t *testing.T) {
+	util.Log.Info("Verify OCP version")
+	msg, _ := util.Shell(`oc version | awk '{print $3}' | sed -n 2p | head -c4`)
+	if strings.Contains(msg, "4.11") {
+		util.Log.Info("Skipping the test case on OCP version 4.11")
+		t.Skip()
+	}
 	defer cleanUpTestExtensionInstall()
 	httpbin := examples.Httpbin{"bookinfo"}
 	sleep := examples.Sleep{"bookinfo"}


### PR DESCRIPTION
PR to disable T25 test case for interop testing. Reference bug - https://issues.redhat.com/browse/OSSM-1505