### PR TITLE
Disable T25 test case for interop testing for maistra-2.1

### DIFF
--- a/tests/test_cases.go
+++ b/tests/test_cases.go
@@ -194,10 +194,10 @@ var testCases = []testing.InternalTest{
 		F:    authorizaton.TestTrustDomainMigration,
 	},
 
-	testing.InternalTest{
-		Name: "T25",
-		F:    ossm.TestExtensionInstall,
-	},
+	//testing.InternalTest{
+	//	Name: "T25",
+	//	F:    ossm.TestExtensionInstall,
+	//},
 	testing.InternalTest{
 		Name: "T26",
 		F:    ossm.TestTLSVersionSMCP,


### PR DESCRIPTION
As the fix for skip test on OCP 4.11 is not yet done, creating PR to temporary disable the T25 test for interop testing