### PR TITLE
OSSM-2078 Fix egress gateway mtls flaky tests

### DIFF
--- a/pkg/examples/nginx.go
+++ b/pkg/examples/nginx.go
@@ -40,19 +40,20 @@ func (n *Nginx) Install(config string) {
 	time.Sleep(time.Duration(10) * time.Second)
 }
 
-func (n *Nginx) Install_mTLS(config, serverCertKey, serverCert string) {
+// Install_mTLS deploys a nginx server with mtls config in mesh-external namespace
+func (n *Nginx) Install_mTLS(config string) {
 	util.Log.Info("Create Secret")
-	util.CreateTLSSecret("nginx-server-certs", n.Namespace, serverCertKey, serverCert)
-	util.Shell(`kubectl create -n %s secret generic nginx-ca-certs --from-file=%s`, n.Namespace, nginxServerCACert)
+	util.CreateTLSSecret("nginx-server-certs", "mesh-external", meshExtServerCertKey, meshExtServerCert)
+	util.Shell(`kubectl create -n %s secret generic nginx-ca-certs --from-file=%s`, "mesh-external", nginxServerCACert)
 
 	util.Log.Info("Create ConfigMap")
-	util.Shell(`kubectl create configmap nginx-configmap --from-file=nginx.conf=%s -n %s`, config, n.Namespace)
+	util.Shell(`kubectl create configmap nginx-configmap --from-file=nginx.conf=%s -n %s`, config, "mesh-external")
 	time.Sleep(time.Duration(5) * time.Second)
 
 	util.Log.Info("Deploy Nginx")
-	util.KubeApply(n.Namespace, nginxYaml)
+	util.KubeApply("mesh-external", nginxYaml)
 	time.Sleep(time.Duration(5) * time.Second)
-	util.CheckPodRunning(n.Namespace, "run=my-nginx")
+	util.CheckPodRunning("mesh-external", "run=my-nginx")
 	time.Sleep(time.Duration(10) * time.Second)
 }
 

--- a/pkg/examples/yaml_vars.go
+++ b/pkg/examples/yaml_vars.go
@@ -49,11 +49,13 @@ var (
 	httpbinv1Yaml     = fmt.Sprintf("%s/%s/httpbin/httpbinv1.yaml", basedir, branch)
 	httpbinv2Yaml     = fmt.Sprintf("%s/%s/httpbin/httpbinv2.yaml", basedir, branch)
 
-	nginxServerCertKey = fmt.Sprintf("%s/nginx.example.com/nginx.example.com.key", certdir)
-	nginxServerCert    = fmt.Sprintf("%s/nginx.example.com/nginx.example.com.crt", certdir)
-	nginxServerCACert  = fmt.Sprintf("%s/nginx.example.com/example.com.crt", certdir)
-	nginxConf          = fmt.Sprintf("%s/%s/nginx/nginx.conf", basedir, branch)
-	nginxYaml          = fmt.Sprintf("%s/%s/nginx/nginx.yaml", basedir, branch)
+	nginxServerCertKey   = fmt.Sprintf("%s/nginx.example.com/nginx.example.com.key", certdir)
+	nginxServerCert      = fmt.Sprintf("%s/nginx.example.com/nginx.example.com.crt", certdir)
+	nginxServerCACert    = fmt.Sprintf("%s/nginx.example.com/example.com.crt", certdir)
+	meshExtServerCertKey = fmt.Sprintf("%s/nginx.example.com/my-nginx.mesh-external.svc.cluster.local.key", certdir)
+	meshExtServerCert    = fmt.Sprintf("%s/nginx.example.com/my-nginx.mesh-external.svc.cluster.local.crt", certdir)
+	nginxConf            = fmt.Sprintf("%s/%s/nginx/nginx.conf", basedir, branch)
+	nginxYaml            = fmt.Sprintf("%s/%s/nginx/nginx.yaml", basedir, branch)
 
 	redisYaml = fmt.Sprintf("%s/%s/redis/redis.yaml", basedir, branch)
 

--- a/pkg/tasks/traffic/egress/yaml_vars.go
+++ b/pkg/tasks/traffic/egress/yaml_vars.go
@@ -22,9 +22,6 @@ const (
 	nginxClientCertKey = "../sampleCerts/nginx.example.com/nginx-client.example.com.key"
 	nginxClientCert    = "../sampleCerts/nginx.example.com/nginx-client.example.com.crt"
 	nginxServerCACert  = "../sampleCerts/nginx.example.com/example.com.crt"
-
-	meshExtServerCertKey = "../sampleCerts/nginx.example.com/my-nginx.mesh-external.svc.cluster.local.key"
-	meshExtServerCert    = "../sampleCerts/nginx.example.com/my-nginx.mesh-external.svc.cluster.local.crt"
 )
 
 type SMCP struct {

--- a/pkg/tasks/traffic/ingress/yaml_configs.go
+++ b/pkg/tasks/traffic/ingress/yaml_configs.go
@@ -366,6 +366,6 @@ spec:
     - destination:
         host: my-nginx
         port:
-          number: 8443
+          number: 443
 `
 )

--- a/testdata/examples/x86/nginx/nginx.yaml
+++ b/testdata/examples/x86/nginx/nginx.yaml
@@ -6,7 +6,7 @@ metadata:
     run: my-nginx
 spec:
   ports:
-  - port: 8443
+  - port: 443
     targetPort: 8443
     protocol: TCP
   selector:

--- a/tests/test_cases.go
+++ b/tests/test_cases.go
@@ -154,6 +154,10 @@ var testCases = []testing.InternalTest{
 		F:    egress.TestEgressGateways,
 	},
 	testing.InternalTest{
+		Name: "T14",
+		F:    egress.TestTLSOriginationFileMount,
+	},
+	testing.InternalTest{
 		Name: "T15",
 		F:    egress.TestTLSOriginationSDS,
 	},


### PR DESCRIPTION
Signed-off-by: Yuanlin <yuanlin.xu@redhat.com>

This PR adds the egress gateway mtls ori tests (file mount and SDS) back when testing on an OCP cluster.
The main difference between upstream istio.io doc and our steps is applying an additional ServiceEntry for egress gateway resolving the hosts such as "my-nginx.mesh-external.svc.cluster.local" in a VirtualService route.
