### PR TITLE
Update ratelimit.go

### DIFF
--- a/pkg/ossm/ratelimit.go
+++ b/pkg/ossm/ratelimit.go
@@ -176,7 +176,7 @@ func TestRateLimiting(t *testing.T) {
 	checkProductPageResponseCode(t, host, "200")
 
 	// Should fail
-	time.Sleep(time.Second * 15)
+	time.Sleep(time.Second * 20)
 	checkProductPageResponseCode(t, host, "429")
 }
 


### PR DESCRIPTION
Increased the time limit for URL 

Tested on OCP 4.10 and OCP 4.10, It passed successfully in the local

We are getting the expected Status code when it requests to URL