### PR TITLE
Improve T35 testcase to avoid errors over ROSA cluster

### DIFF
--- a/pkg/ossm/bug_istiopods.go
+++ b/pkg/ossm/bug_istiopods.go
@@ -60,14 +60,14 @@ func TestIstioPodProbesFails(t *testing.T) {
 			deleted, _ := util.CheckPodDeletion(`istio-system`, `app=istiod`, istiod, 60)
 			if deleted {
 				util.Log.Info("*** Istiod pod deleted: ", istiod)
-				ready := util.CheckPodRunning(`istio-system`, `app=istiod`)
-				if ready == nil {
+				running := util.CheckPodRunning(`istio-system`, `app=istiod`)
+				if running == nil {
 					util.Log.Info("*** New Istiod pod is running")
-					status, _ := util.Shell(`oc get pods -n istio-system | grep istiod | awk '{print $2}'`)
-					istiod, _ = util.GetPodName(`istio-system`, `app=istiod`)
-					if strings.Contains(status, `1/1`) {
-						util.Log.Info("*** Istiod pod is running: ", istiod)
+					ready, _ := util.CheckPodReady(`istio-system`, `app=istiod`, 10)
+					if ready {
+						util.Log.Info("*** New Istiod pod is ready")
 					} else {
+						istiod, _ = util.GetPodName(`istio-system`, `app=istiod`)
 						//Get events that are not type = Normal from the pod
 						event, _ := util.Shell(`kubectl get events  -n istio-system --field-selector type!=Normal,involvedObject.name=%s |tail -1`, istiod)
 						if strings.Contains(event, "Readiness probe failed") {

--- a/pkg/util/kube.go
+++ b/pkg/util/kube.go
@@ -420,7 +420,7 @@ func GetPodName(n, labelSelector string) (pod string, err error) {
 }
 
 // Check PodReady (Example: 2/2 container running on a pod) returns true if the pod is ready. Params: namespace, pod label and timeout to check ready pod.
-func CheckPodReady(n, labelSelector string, timeout int) (ready bool, err error) {
+func CheckPodReady(ns, selector string, timeout time.Duration) (bool, error) {
 	ready = false
 	for i := 0; i < timeout; i++ {
 		pod, err := GetPodName(n, labelSelector)

--- a/pkg/util/kube.go
+++ b/pkg/util/kube.go
@@ -420,35 +420,28 @@ func GetPodName(n, labelSelector string) (pod string, err error) {
 }
 
 // Check PodReady (Example: 2/2 container running on a pod) returns true if the pod is ready. Params: namespace, pod label and timeout to check ready pod.
-func CheckPodReady(ns, selector string, timeout time.Duration) (bool, error) {
-	ready = false
-	for i := 0; i < timeout; i++ {
-		pod, err := GetPodName(n, labelSelector)
-		status, _ := Shell(`oc get pod %s -n istio-system | grep istiod | awk '{print $2}'`, pod)
-		if err != nil {
-			return ready, err
-		}
-		//split status to get the number of containers expected to be running
-		s := strings.Split(status, "/")
-		//trim the status to get the number of containers running without spaces
-		s[0] = strings.Trim(s[0], "\r\n")
-		s[1] = strings.Trim(s[1], "\r\n")
-
-		if len(s) < 2 {
-			return ready, fmt.Errorf("*** unexpected status format: %s", status)
-		}
-		//check if the number of containers running is equal to the number of containers expected to be running
-		if s[0] != s[1] {
-			time.Sleep(time.Duration(1) * time.Second)
-			Log.Infof(`*** Pod status is not ready: %s of %s. Checking again in 1 second`, s[0], s[1])
-			continue
-		} else {
-			Log.Infof("*** Pod status: %s of %s ready", s[0], s[1])
-			ready = true
-			return ready, nil
-		}
+func CheckPodReady(ns, selector string, retries int) (bool, error) {
+	ready := false
+	retry := Retrier{
+		BaseDelay: 1 * time.Second,
+		MaxDelay:  1 * time.Second,
+		Retries:   retries,
 	}
-	return false, nil
+	_, err := retry.Retry(context.Background(), func(_ context.Context, _ int) error {
+		output, err := Shell(`oc get pods -n istio-system -l %s -o jsonpath='{range .items[*]}{.status.containerStatuses[*].ready}'`, selector)
+		if err != nil {
+			ready = false
+			return fmt.Errorf("failed to get pod: %s", err)
+		}
+		if strings.Contains(output, "false") {
+			ready = false
+			return fmt.Errorf("pod is not ready")
+		} else {
+			ready = true
+			return nil
+		}
+	})
+	return ready, err
 }
 
 // CheckPodDeletion returns true if the pod is deleted. Params: label of the pod, the Pod Name to check,  namespace and a timeout

--- a/pkg/util/kube.go
+++ b/pkg/util/kube.go
@@ -430,11 +430,9 @@ func CheckPodReady(ns, selector string, retries int) (bool, error) {
 	_, err := retry.Retry(context.Background(), func(_ context.Context, _ int) error {
 		output, err := Shell(`oc get pods -n istio-system -l %s -o jsonpath='{range .items[*]}{.status.containerStatuses[*].ready}'`, selector)
 		if err != nil {
-			ready = false
 			return fmt.Errorf("failed to get pod: %s", err)
 		}
 		if strings.Contains(output, "false") {
-			ready = false
 			return fmt.Errorf("pod is not ready")
 		} else {
 			ready = true


### PR DESCRIPTION
After testing the T35 over a ROSA cluster the test case fails because the container inside the pod fails the first readiness probe, So I include an improvement to check when the container is n of n ready

https://issues.redhat.com/browse/OSSM-3023
