### PR TITLE
Adding retry and fail for federation install script to avoid empty ce…

### DIFF
--- a/pkg/federation/fed_single_cluster_install.go
+++ b/pkg/federation/fed_single_cluster_install.go
@@ -46,7 +46,7 @@ func TestSingleClusterFed(t *testing.T) {
 	t.Run("federation_single_cluster_install", func(t *testing.T) {
 		defer util.RecoverPanic(t)
 		util.Log.Info("Test federation install in a single cluster")
-		util.Log.Info("Reference: https://github.com/maistra/istio/blob/maistra-2.1/pkg/servicemesh/federation/example/config-poc/install.sh")
+		util.Log.Info("Reference: https://github.com/maistra/istio/blob/maistra-2.4/samples/federation/base/install.sh")
 		util.Log.Info("Running install.sh waiting 1 min...")
 		util.Shell(`pushd ../testdata/examples/federation \
 			&& export MESH1_KUBECONFIG=~/.kube/config \

--- a/pkg/federation/fed_single_cluster_install.go
+++ b/pkg/federation/fed_single_cluster_install.go
@@ -46,7 +46,7 @@ func TestSingleClusterFed(t *testing.T) {
 	t.Run("federation_single_cluster_install", func(t *testing.T) {
 		defer util.RecoverPanic(t)
 		util.Log.Info("Test federation install in a single cluster")
-		util.Log.Info("Reference: https://github.com/maistra/istio/blob/maistra-2.4/samples/federation/base/install.sh")
+		util.Log.Info("Reference: https://github.com/maistra/istio/blob/maistra-2.3/samples/federation/base/install.sh")
 		util.Log.Info("Running install.sh waiting 1 min...")
 		util.Shell(`pushd ../testdata/examples/federation \
 			&& export MESH1_KUBECONFIG=~/.kube/config \

--- a/testdata/examples/failover/install.sh
+++ b/testdata/examples/failover/install.sh
@@ -23,6 +23,23 @@ log "Retrieving root certificates"
 WEST_MESH_CERT=$(oc1 get configmap -n west-mesh-system istio-ca-root-cert -o jsonpath='{.data.root-cert\.pem}' | sed ':a;N;$!ba;s/\n/\\\n    /g')
 EAST_MESH_CERT=$(oc2 get configmap -n east-mesh-system istio-ca-root-cert -o jsonpath='{.data.root-cert\.pem}' | sed ':a;N;$!ba;s/\n/\\\n    /g')
 
+if [ -z "$WEST_MESH_CERT" ]; then
+  sleep 60
+  WEST_MESH_CERT=$(oc1 get configmap -n west-mesh-system istio-ca-root-cert -o jsonpath='{.data.root-cert\.pem}' | sed ':a;N;$!ba;s/\n/\\\n    /g')
+  if [ -z "$WEST_MESH_CERT" ]; then
+    echo "FATAL: Could not retrieve root certificate for west-mesh"
+    exit 1
+  fi
+fi
+if [ -z "$EAST_MESH_CERT" ]; then
+  sleep 60
+  EAST_MESH_CERT=$(oc2 get configmap -n east-mesh-system istio-ca-root-cert -o jsonpath='{.data.root-cert\.pem}' | sed ':a;N;$!ba;s/\n/\\\n    /g')
+  if [ -z "$EAST_MESH_CERT" ]; then
+    echo "FATAL: Could not retrieve root certificate for east-mesh"
+    exit 1
+  fi
+fi
+
 WEST_MESH_DISCOVERY_PORT="${MESH1_DISCOVERY_PORT:-8188}"
 WEST_MESH_SERVICE_PORT="${MESH1_SERVICE_PORT:-15443}"
 EAST_MESH_DISCOVERY_PORT="${MESH2_DISCOVERY_PORT:-8188}"

--- a/testdata/examples/federation/install.sh
+++ b/testdata/examples/federation/install.sh
@@ -44,7 +44,22 @@ oc2 wait --for condition=Ready -n mesh2-system smcp/fed-import --timeout 300s
 log "Retrieving root certificates"
 MESH1_CERT=$(oc1 get configmap -n mesh1-system istio-ca-root-cert -o jsonpath='{.data.root-cert\.pem}' | sed ':a;N;$!ba;s/\n/\\\n    /g')
 MESH2_CERT=$(oc2 get configmap -n mesh2-system istio-ca-root-cert -o jsonpath='{.data.root-cert\.pem}' | sed ':a;N;$!ba;s/\n/\\\n    /g')
-
+if [ -z "$MESH1_CERT" ]; then
+  sleep 60
+  MESH1_CERT=$(oc1 get configmap -n mesh1-system istio-ca-root-cert -o jsonpath='{.data.root-cert\.pem}' | sed ':a;N;$!ba;s/\n/\\\n    /g')
+  if [ -z "$MESH1_CERT" ]; then
+    echo "FATAL: Could not retrieve root certificate for mesh1"
+    exit 1
+  fi
+fi
+if [ -z "$MESH2_CERT" ]; then
+  sleep 60
+  MESH2_CERT=$(oc2 get configmap -n mesh2-system istio-ca-root-cert -o jsonpath='{.data.root-cert\.pem}' | sed ':a;N;$!ba;s/\n/\\\n    /g')
+  if [ -z "$MESH2_CERT" ]; then
+    echo "FATAL: Could not retrieve root certificate for mesh2"
+    exit 1
+  fi
+fi
 MESH1_DISCOVERY_PORT="8188"
 MESH1_SERVICE_PORT="15443"
 MESH2_DISCOVERY_PORT="8188"


### PR DESCRIPTION
Adding retry and fail for install script for federation when the certificate retrieves root certificates for one of the mesh is empty (Related to https://issues.redhat.com/browse/OSSM-3237). Additionally, change the reference for the installation script to maistra 2.4 script