### PR TITLE
Ipv6 httpbin support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ ENV TEST_CASE ${TEST_CASE}
 ENV ROSA ${ROSA}
 ENV GODEBUG "x509ignoreCN=0"
 ENV MUSTGATHERTAG ${MUSTGATHERTAG}
+ENV IPV6 ${IPV6}
 
 COPY . /opt/maistra-test-tool
 WORKDIR /opt/maistra-test-tool/tests

--- a/pkg/util/kube.go
+++ b/pkg/util/kube.go
@@ -68,6 +68,7 @@ func Fill(outFile, inFile string, values interface{}) error {
 
 	var filled bytes.Buffer
 	w := bufio.NewWriter(&filled)
+	Log.Info("Filling template ", inFile, " with values ", values)
 	if err := tmpl.Execute(w, values); err != nil {
 		return err
 	}

--- a/testdata/examples/x86/httpbin/httpbin.yaml
+++ b/testdata/examples/x86/httpbin/httpbin.yaml
@@ -60,4 +60,4 @@ spec:
         name: httpbin
         ports:
         - containerPort: 8000
-        command: ["gunicorn", "-b", "{{ .Bind }}", "httpbin:app", "-k", "gevent"]
+        command: ["gunicorn", "-b", "[::]:8000", "httpbin:app", "-k", "gevent"]

--- a/testdata/examples/x86/httpbin/httpbin.yaml
+++ b/testdata/examples/x86/httpbin/httpbin.yaml
@@ -60,4 +60,4 @@ spec:
         name: httpbin
         ports:
         - containerPort: 8000
-        command: ["gunicorn", "-b", "0.0.0.0:8000", "httpbin:app", "-k", "gevent"]
+        command: ["gunicorn", "-b", "{{ .Bind }}", "httpbin:app", "-k", "gevent"]

--- a/testdata/examples/x86/httpbin/httpbin_legacy.yaml
+++ b/testdata/examples/x86/httpbin/httpbin_legacy.yaml
@@ -57,4 +57,4 @@ spec:
         name: httpbin
         ports:
         - containerPort: 8000
-        command: ["gunicorn", "-b", "0.0.0.0:8000", "httpbin:app", "-k", "gevent"]
+        command: ["gunicorn", "-b", "{{ .Bind }}", "httpbin:app", "-k", "gevent"]

--- a/testdata/examples/x86/httpbin/httpbin_legacy.yaml
+++ b/testdata/examples/x86/httpbin/httpbin_legacy.yaml
@@ -57,4 +57,4 @@ spec:
         name: httpbin
         ports:
         - containerPort: 8000
-        command: ["gunicorn", "-b", "{{ .Bind }}", "httpbin:app", "-k", "gevent"]
+        command: ["gunicorn", "-b", "[::]:8000", "httpbin:app", "-k", "gevent"]

--- a/testdata/examples/x86/httpbin/httpbinv1.yaml
+++ b/testdata/examples/x86/httpbin/httpbinv1.yaml
@@ -40,6 +40,6 @@ spec:
       - image: docker.io/kennethreitz/httpbin
         imagePullPolicy: IfNotPresent
         name: httpbin
-        command: ["gunicorn", "--access-logfile", "-", "-b", "0.0.0.0:8000", "httpbin:app"]
+        command: ["gunicorn", "--access-logfile", "-", "-b", "{{ .Bind }}", "httpbin:app"]
         ports:
         - containerPort: 8000

--- a/testdata/examples/x86/httpbin/httpbinv1.yaml
+++ b/testdata/examples/x86/httpbin/httpbinv1.yaml
@@ -40,6 +40,6 @@ spec:
       - image: docker.io/kennethreitz/httpbin
         imagePullPolicy: IfNotPresent
         name: httpbin
-        command: ["gunicorn", "--access-logfile", "-", "-b", "{{ .Bind }}", "httpbin:app"]
+        command: ["gunicorn", "--access-logfile", "-", "-b", "[::]:8000", "httpbin:app"]
         ports:
         - containerPort: 8000

--- a/testdata/examples/x86/httpbin/httpbinv2.yaml
+++ b/testdata/examples/x86/httpbin/httpbinv2.yaml
@@ -40,6 +40,6 @@ spec:
       - image: docker.io/kennethreitz/httpbin
         imagePullPolicy: IfNotPresent
         name: httpbin
-        command: ["gunicorn", "--access-logfile", "-", "-b", "0.0.0.0:8000", "httpbin:app"]
+        command: ["gunicorn", "--access-logfile", "-", "-b", "{{ .Bind }}", "httpbin:app"]
         ports:
         - containerPort: 8000

--- a/testdata/examples/x86/httpbin/httpbinv2.yaml
+++ b/testdata/examples/x86/httpbin/httpbinv2.yaml
@@ -40,6 +40,6 @@ spec:
       - image: docker.io/kennethreitz/httpbin
         imagePullPolicy: IfNotPresent
         name: httpbin
-        command: ["gunicorn", "--access-logfile", "-", "-b", "{{ .Bind }}", "httpbin:app"]
+        command: ["gunicorn", "--access-logfile", "-", "-b", "[::]:8000", "httpbin:app"]
         ports:
         - containerPort: 8000

--- a/tests/test.env
+++ b/tests/test.env
@@ -5,3 +5,4 @@ export SAMPLEARCH=x86
 export ROSA=false
 export TEST_GROUP=full
 export MUSTGATHERTAG=2.3
+export IPV6=true

--- a/tests/test.env
+++ b/tests/test.env
@@ -5,4 +5,4 @@ export SAMPLEARCH=x86
 export ROSA=false
 export TEST_GROUP=full
 export MUSTGATHERTAG=2.3
-export IPV6=true
+export IPV6=false


### PR DESCRIPTION
Adding support for ipv6 to httpbin example app, bind address can be set to IPv4 or IPv6 using IPV6 env variable for maistra test tool