### PR TITLE
Adding support for IPv6 on testssl.sh

### DIFF
--- a/pkg/ossm/smcp_tls_ssl.go
+++ b/pkg/ossm/smcp_tls_ssl.go
@@ -117,7 +117,7 @@ func TestSSL(t *testing.T) {
 		pod, err := util.GetPodName("bookinfo", "app=testssl")
 		util.Inspect(err, "failed to get testssl pod", "", t)
 
-		command := "./testssl/testssl.sh productpage:9080"
+		command := "./testssl/testssl.sh -6 productpage:9080"
 		msg, err := util.PodExec("bookinfo", pod, "testssl", command, false)
 		if !strings.Contains(msg, "TLSv1.2") {
 			t.Errorf("Results not include: TLSv1.2")


### PR DESCRIPTION
In the test case, T27 TestSSL needs to pass to the command ./testssl/testssl.sh the flag -6 to add support to IPv6 according to the documentation: 
https://testssl.sh/#:~:text=http(s)_proxy)-,%2D6,-also%20use%20IPv6

Was tested on IPv4 OCP cluster to check compatibility:
`servicemeshcontrolplane.maistra.io/basic condition met
--- PASS: T27 (232.25s)
    --- PASS: T27/Operator_test_smcp_testssl (196.18s)`

