### PR TITLE
Set proxy variables from oc get proxy to avoid issue on IPv6 cluster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ ENV TEST_CASE ${TEST_CASE}
 ENV ROSA ${ROSA}
 ENV GODEBUG "x509ignoreCN=0"
 ENV MUSTGATHERTAG ${MUSTGATHERTAG}
+ENV IPV6 ${IPV6}
 
 COPY . /opt/maistra-test-tool
 WORKDIR /opt/maistra-test-tool/tests

--- a/pkg/examples/sleep.go
+++ b/pkg/examples/sleep.go
@@ -63,6 +63,9 @@ func (s *Sleep) InstallLegacy() {
 
 func (s *Sleep) Uninstall() {
 	util.Log.Infof("Removing Sleep on namespace %s", s.Namespace)
+	proxy, _ := util.GetProxy()
+	configmap := util.RunTemplate(sleepConfigmap, proxy)
+	util.KubeDeleteContents(s.Namespace, configmap)
 	util.KubeDelete(s.Namespace, sleepYaml)
 	util.Shell(`oc -n %s wait --for=delete -l app=sleep pods --timeout=30s`, s.Namespace)
 }

--- a/pkg/ossm/init.go
+++ b/pkg/ossm/init.go
@@ -41,4 +41,8 @@ func init() {
 	util.KubeApplyContents(meshNamespace, util.RunTemplate(smcpV23_template, smcp))
 	util.KubeApplyContents(meshNamespace, smmr)
 	time.Sleep(time.Duration(30) * time.Second)
+	if ipv6 == "true" {
+		util.Log.Info("Running the test with IPv6 configuration")
+	}
+
 }

--- a/pkg/ossm/yaml_vars.go
+++ b/pkg/ossm/yaml_vars.go
@@ -33,4 +33,5 @@ var (
 	smcpName      string = util.Getenv("SMCPNAME", "basic")
 	meshNamespace string = util.Getenv("MESHNAMESPACE", "istio-system")
 	smcp          SMCP   = SMCP{smcpName, meshNamespace}
+	ipv6          string = util.Getenv("IPV6", "false")
 )

--- a/pkg/tasks/traffic/egress/egress_gateways.go
+++ b/pkg/tasks/traffic/egress/egress_gateways.go
@@ -15,6 +15,7 @@
 package egress
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -43,15 +44,20 @@ func TestEgressGateways(t *testing.T) {
 	sleep.Install()
 	sleepPod, err := util.GetPodName("bookinfo", "app=sleep")
 	util.Inspect(err, "Failed to get sleep pod name", "", t)
-
+	proxy, _ := util.GetProxy()
+	curlParams := ""
+	if proxy.HTTPProxy == "" {
+		util.Log.Info("HTTP_PROXY is not set")
+	} else {
+		curlParams = curlParams + " -x " + proxy.HTTPProxy
+	}
 	t.Run("TrafficManagement_egress_gateway_for_http_traffic", func(t *testing.T) {
 		defer util.RecoverPanic(t)
 
 		util.Log.Info("Create a ServiceEntry to external istio.io")
 		util.KubeApplyContents("bookinfo", ExServiceEntry)
 		time.Sleep(time.Duration(10) * time.Second)
-
-		command := `curl -sSL -o /dev/null -D - http://istio.io`
+		command := fmt.Sprintf(`curl -sSL -o /dev/null %s -D - http://istio.io`, curlParams)
 		msg, err := util.PodExec("bookinfo", sleepPod, "sleep", command, false)
 		util.Inspect(err, "Failed to get response", "", t)
 		if strings.Contains(msg, "301 Moved Permanently") {
@@ -65,7 +71,7 @@ func TestEgressGateways(t *testing.T) {
 		util.KubeApplyContents("bookinfo", util.RunTemplate(ExGatewayTemplate, smcp))
 		time.Sleep(time.Duration(20) * time.Second)
 
-		command = `curl -sSL -o /dev/null -D - http://istio.io`
+		command = fmt.Sprintf(`curl -sSL -o /dev/null %s -D - http://istio.io`, curlParams)
 		msg, err = util.PodExec("bookinfo", sleepPod, "sleep", command, false)
 		util.Inspect(err, "Failed to get response", "", t)
 		if strings.Contains(msg, "301 Moved Permanently") {

--- a/pkg/util/kube.go
+++ b/pkg/util/kube.go
@@ -43,6 +43,12 @@ const (
 	LoadBalancerServiceType = "LoadBalancer"
 )
 
+type Proxy struct {
+	HTTPProxy  string `json:"httpProxy"`
+	HTTPSProxy string `json:"httpsProxy"`
+	NoProxy    string `json:"noProxy"`
+}
+
 var (
 	logDumpResources = []string{
 		"pod",
@@ -737,4 +743,49 @@ func DeleteMultiClusterSecret(namespace string, remoteKubeConfig string, localKu
 		Log.Infof("Deleted secret %s", secretName)
 	}
 	return err
+}
+
+// GetJsonObject get json string as input and returns a map of the json string
+func GetJsonObject(jsonString string) (map[string]interface{}, error) {
+	var result map[string]interface{}
+	err := json.Unmarshal([]byte(jsonString), &result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// GetHTTPProxy returns the Proxy struc object from the cluster
+func GetProxy() (*Proxy, error) {
+	Proxy := &Proxy{}
+	proxyString, err := ShellSilent(`oc get Proxy -o json`)
+	if err != nil {
+		Log.Error("Error getting proxy String")
+		return nil, err
+	}
+	proxyObject, err := GetJsonObject(proxyString)
+	if err != nil {
+		Log.Error("Error getting proxy object")
+		return nil, err
+	}
+	proxyObject = proxyObject["items"].([]interface{})[0].(map[string]interface{})
+	if proxyObject["status"] != nil {
+		proxyStatus := proxyObject["status"].(map[string]interface{})
+		if proxyStatus["httpProxy"] != nil && proxyStatus["httpsProxy"] != nil {
+			Proxy.HTTPProxy = proxyStatus["httpProxy"].(string)
+			Proxy.HTTPSProxy = proxyStatus["httpsProxy"].(string)
+			Log.Info("Current httpProxy: ", Proxy.HTTPProxy)
+			Log.Info("Current httpsProxy: ", Proxy.HTTPSProxy)
+			if proxyStatus["noProxy"] != nil {
+				Proxy.NoProxy = proxyStatus["noProxy"].(string)
+				Log.Info("Current noProxy: ", Proxy.NoProxy)
+			}
+		}
+	} else {
+		Log.Info("No proxy variables need to be configured")
+		Proxy.HTTPProxy = ""
+		Proxy.HTTPSProxy = ""
+		Proxy.NoProxy = ""
+	}
+	return Proxy, nil
 }

--- a/testdata/examples/x86/sleep/sleep.yaml
+++ b/testdata/examples/x86/sleep/sleep.yaml
@@ -55,6 +55,22 @@ spec:
       - name: sleep
         image: curlimages/curl
         command: ["/bin/sleep", "3650d"]
+        env:
+        - name: HTTPS_PROXY
+          valueFrom:
+            configMapKeyRef:
+              name: sleep-configmap
+              key: https-proxy
+        - name: HTTP_PROXY
+          valueFrom:
+            configMapKeyRef:
+              name: sleep-configmap
+              key: http-proxy
+        - name: NO_PROXY
+          valueFrom:
+            configMapKeyRef:
+              name: sleep-configmap
+              key: no-proxy
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - mountPath: /etc/sleep/tls

--- a/testdata/examples/x86/sleep/sleep_legacy.yaml
+++ b/testdata/examples/x86/sleep/sleep_legacy.yaml
@@ -53,6 +53,22 @@ spec:
       - name: sleep
         image: curlimages/curl
         command: ["/bin/sleep", "3650d"]
+        env:
+        - name: HTTPS_PROXY
+          valueFrom:
+            configMapKeyRef:
+              name: sleep-configmap
+              key: https-proxy
+        - name: HTTP_PROXY
+          valueFrom:
+            configMapKeyRef:
+              name: sleep-configmap
+              key: http-proxy
+        - name: NO_PROXY
+          valueFrom:
+            configMapKeyRef:
+              name: sleep-configmap
+              key: no-proxy
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - mountPath: /etc/sleep/tls

--- a/tests/test.env
+++ b/tests/test.env
@@ -5,3 +5,4 @@ export SAMPLEARCH=x86
 export ROSA=false
 export TEST_GROUP=full
 export MUSTGATHERTAG=2.3
+export IPV6=false


### PR DESCRIPTION
Looking to improve the code and simplify the run of the test cases over the IPv6 cluster that uses PROXY env variables, I made some changes to the code to set some curl to the internet using -x flag and to set the proxy env variable to sleep pod.

The issue related on jira: https://issues.redhat.com/browse/OSSM-3377
