### PR TITLE
T40

### DIFF
--- a/pkg/ossm/operator.go
+++ b/pkg/ossm/operator.go
@@ -109,6 +109,8 @@ func TestOperator(t *testing.T) {
 	t.Run("test_ossm_smcp_elements_deploy_infra_nodes", func(t *testing.T) {
 		defer util.RecoverPanic(t)
 		util.Log.Info("Testing: Run all the SMCP elements on infra nodes")
+		util.Log.Info("Check SMCP status")
+		util.Shell(`oc -n %s wait --for condition=Ready smcp/%s --timeout 300s`, meshNamespace, smcpName)
 		util.Shell(`oc get pods -n %s -o wide`, meshNamespace)
 		_, err = util.Shell(`oc -n %s patch smcp/%s --type merge -p '{"spec":{"runtime":{"defaults":{"pod":{"nodeSelector":{"node-role.kubernetes.io/infra":""},"tolerations":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/infra","value":"reserved"},{"effect":"NoExecute","key":"node-role.kubernetes.io/infra","value":"reserved"}]}}}}}'`, meshNamespace, smcpName)
 		util.Shell(`oc -n %s wait --for condition=Ready smcp/%s --timeout 180s`, meshNamespace, smcpName)

--- a/pkg/ossm/operator.go
+++ b/pkg/ossm/operator.go
@@ -52,7 +52,9 @@ func cleanupOperatorTest() {
 func TestOperator(t *testing.T) {
 	defer cleanupOperatorTest()
 	defer util.RecoverPanic(t)
-
+	if util.Getenv("ROSA", "false") == "true" {
+		t.Skip("Skipping test on ROSA")
+	}
 	util.Log.Info("Test cases related to OSSM Operators")
 	//Get and pick one worker node that does not have already installed the istio operator
 	workername = pickWorkerNode(t)


### PR DESCRIPTION
Adding two fixes for the T40 test case:

- https://issues.redhat.com/browse/OSSM-3594: added a verification at the beginning of the test case test_ossm_smcp_elements_deploy_infra_nodes to verify if the smcp it's ready or not. With this, we ensure that the test is going to be executed when the pod is in the correct state
- https://issues.redhat.com/browse/OSSM-3563: avoid the execution of this test case in ROSA (because the test is failing for lack of permissions) 