### PR TITLE
Increase wait time for smcp ready in T40 execution

### DIFF
--- a/pkg/ossm/operator.go
+++ b/pkg/ossm/operator.go
@@ -110,10 +110,10 @@ func TestOperator(t *testing.T) {
 		defer util.RecoverPanic(t)
 		util.Log.Info("Testing: Run all the SMCP elements on infra nodes")
 		util.Log.Info("Check SMCP status")
-		util.Shell(`oc -n %s wait --for condition=Ready smcp/%s --timeout 300s`, meshNamespace, smcpName)
+		util.Shell(`oc -n %s wait --for condition=Ready smcp/%s --timeout 480s`, meshNamespace, smcpName)
 		util.Shell(`oc get pods -n %s -o wide`, meshNamespace)
 		_, err = util.Shell(`oc -n %s patch smcp/%s --type merge -p '{"spec":{"runtime":{"defaults":{"pod":{"nodeSelector":{"node-role.kubernetes.io/infra":""},"tolerations":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/infra","value":"reserved"},{"effect":"NoExecute","key":"node-role.kubernetes.io/infra","value":"reserved"}]}}}}}'`, meshNamespace, smcpName)
-		util.Shell(`oc -n %s wait --for condition=Ready smcp/%s --timeout 180s`, meshNamespace, smcpName)
+		util.Shell(`oc -n %s wait --for condition=Ready smcp/%s --timeout 300s`, meshNamespace, smcpName)
 		if err != nil {
 			t.Fatalf("Failed to patch the smcp")
 		}


### PR DESCRIPTION
We need to increase the wait time for the smcp condition Ready to avoid Flaky test execution