### PR TITLE
refactor the t36 test case

### DIFF
--- a/pkg/ossm/bug_multiple_smcp.go
+++ b/pkg/ossm/bug_multiple_smcp.go
@@ -9,42 +9,48 @@ import (
 )
 
 func cleanupMultipleSMCP() {
-	util.Log.Info("Delete the Multiple CP")
-	// util.KubeDeleteContents(meshNamespace, smmr)
-	// util.KubeDeleteContents(meshNamespace, util.RunTemplate(smcpV23_template, smcp))
-	time.Sleep(time.Duration(40) * time.Second)
-	util.KubeDeleteContents(meshNamespace, util.RunTemplate(smcpV23_template_meta, smcp))
-	time.Sleep(time.Duration(40) * time.Second)
+	// util.Log.Info("Delete the Multiple CP")
+	util.KubeDeleteContents(meshNS2, smmr)
+	util.KubeDeleteContents(meshNS2, util.RunTemplate(smcpV23_template, smcp))
+	util.KubeDeleteContents(meshNS2, util.RunTemplate(smcpV23_template_meta, smcp))
+	util.Shell(`oc -n openshift-operators delete pod -l name=istio-operator`)
+
 }
 
 // TestSMCPMutiple tests If multiple SMCPs exist in a namespace, the controller reconciles them all.
 func TestSMCPMutiple(t *testing.T) {
 	defer cleanupMultipleSMCP()
 	defer util.RecoverPanic(t)
-	util.Log.Info("Delete Validation Webhook ")
-	util.Shell(`oc delete validatingwebhookconfiguration/openshift-operators.servicemesh-resources.maistra.io`)
+	util.Log.Info("Delete the Validation Webhook ")
+	validate_webhook, err := util.Shell(`oc delete validatingwebhookconfiguration/openshift-operators.servicemesh-resources.maistra.io`)
+	util.Inspect(err, "Failed to run the command", "", t)
+	if strings.Contains(validate_webhook, "deleted") {
+		util.Log.Infof("Successfully deleted the validation webhook")
+	} else {
+		util.Log.Errorf("Failed to delete the validation webhook")
+	}
 
-	util.ShellMuteOutputError(`oc new-project %s`, meshNamespace)
-	// util.KubeApplyContents(meshNamespace, util.RunTemplate(smcpV23_template, smcp))
-	// util.KubeApplyContents(meshNamespace, smmr)
-	// time.Sleep(time.Duration(20) * time.Second)
-	util.KubeApplyContents(meshNamespace, util.RunTemplate(smcpV23_template_meta, smcp))
+	util.ShellMuteOutputError(`oc new-project %s`, meshNS2)
+	util.KubeApplyContents(meshNS2, util.RunTemplate(smcpV23_template, smcp))
+	util.KubeApplyContents(meshNS2, smmr)
+	time.Sleep(time.Duration(20) * time.Second)
+	util.KubeApplyContents(meshNS2, util.RunTemplate(smcpV23_template_meta, smcp))
 	time.Sleep(time.Duration(20) * time.Second)
 
 	util.Log.Info("Verify SMCP status and pods")
-	msg, _ := util.Shell(`oc get -n %s smcp/%s -o wide`, meshNamespace, smcpName)
+	msg, _ := util.Shell(`oc get -n %s smcp/%s -o wide`, meshNS2, smcpName)
 	if !strings.Contains(msg, "ComponentsReady") {
 		util.Log.Error("SMCP not Ready")
 		t.Error("SMCP not Ready")
 	}
 
 	util.Log.Info("Verify meta control plane and status")
-	text, _ := util.Shell(`oc get -n %s smcp/meta -o wide`, meshNamespace)
+	text, _ := util.Shell(`oc get -n %s smcp/meta -o wide`, meshNS2)
 	if !strings.Contains(text, "ErrMultipleSMCPs") {
 		util.Log.Error("SMCP not Ready")
 		t.Error("SMCP not Ready")
 	}
-	util.Shell(`oc get -n %s pods`, meshNamespace)
-	util.Shell(`oc wait --for=condition=Ready pods --all -n %s`, meshNamespace)
+	util.Shell(`oc get -n %s pods`, meshNS2)
+	util.Shell(`oc wait --for=condition=Ready pods --all -n %s`, meshNS2)
 
 }

--- a/pkg/ossm/yaml_vars.go
+++ b/pkg/ossm/yaml_vars.go
@@ -32,6 +32,7 @@ const (
 var (
 	smcpName      string = util.Getenv("SMCPNAME", "basic")
 	meshNamespace string = util.Getenv("MESHNAMESPACE", "istio-system")
+	meshNS2       string = util.Getenv("MESHNS2", "istio-system2")
 	smcp          SMCP   = SMCP{smcpName, meshNamespace}
 	ipv6          string = util.Getenv("IPV6", "false")
 )

--- a/tests/test_cases.go
+++ b/tests/test_cases.go
@@ -240,10 +240,10 @@ var full = []testing.InternalTest{
 		Name: "T35",
 		F:    ossm.TestIstioPodProbesFails,
 	},
-	// testing.InternalTest{
-	// 	Name: "T36",
-	// 	F:    ossm.TestSMCPMutiple,
-	// },
+	testing.InternalTest{
+		Name: "T36",
+		F:    ossm.TestSMCPMutiple,
+	},
 	testing.InternalTest{
 		Name: "T37",
 		F:    authorizaton.TestExtAuth,


### PR DESCRIPTION
Changes to the T36 test case:

Created the istio-system2 namespace
Deployed the Multiple SMCP on that new namespace
Deleted Istio Operator pod, it will recreate the Webhook back again.

This is already reviewed by Marko. I have updated the latest changes, but unexpectedly this PR is deleted. 

 Here, is the previous PR - https://github.com/maistra/maistra-test-tool/pull/394