### PR TITLE
OSSM-3721 Refactor T21 TestAuthorizationTCPTraffic

### DIFF
--- a/pkg/app/echo-v1.go
+++ b/pkg/app/echo-v1.go
@@ -1,0 +1,54 @@
+// Copyright 2023 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"github.com/maistra/maistra-test-tool/pkg/examples"
+	"github.com/maistra/maistra-test-tool/pkg/util/oc"
+	"github.com/maistra/maistra-test-tool/pkg/util/test"
+)
+
+type echoV1 struct {
+	ns string
+}
+
+var _ App = &echoV1{}
+
+func EchoV1(ns string) App {
+	return &echoV1{ns: ns}
+}
+
+func (a *echoV1) Name() string {
+	return "echo-v1"
+}
+
+func (a *echoV1) Namespace() string {
+	return a.ns
+}
+
+func (a *echoV1) Install(t test.TestHelper) {
+	t.T().Helper()
+	oc.ApplyFile(t, a.ns, examples.EchoV1YamlFile())
+}
+
+func (a *echoV1) Uninstall(t test.TestHelper) {
+	t.T().Helper()
+	oc.DeleteFile(t, a.ns, examples.EchoV1YamlFile())
+}
+
+func (a *echoV1) WaitReady(t test.TestHelper) {
+	t.T().Helper()
+	oc.WaitDeploymentRolloutComplete(t, a.ns, "tcp-echo-v1")
+}

--- a/pkg/app/echo-v2.go
+++ b/pkg/app/echo-v2.go
@@ -1,0 +1,54 @@
+// Copyright 2023 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"github.com/maistra/maistra-test-tool/pkg/examples"
+	"github.com/maistra/maistra-test-tool/pkg/util/oc"
+	"github.com/maistra/maistra-test-tool/pkg/util/test"
+)
+
+type echoV2 struct {
+	ns string
+}
+
+var _ App = &echoV2{}
+
+func EchoV2(ns string) App {
+	return &echoV2{ns: ns}
+}
+
+func (a *echoV2) Name() string {
+	return "echo-v2"
+}
+
+func (a *echoV2) Namespace() string {
+	return a.ns
+}
+
+func (a *echoV2) Install(t test.TestHelper) {
+	t.T().Helper()
+	oc.ApplyFile(t, a.ns, examples.EchoV2YamlFile())
+}
+
+func (a *echoV2) Uninstall(t test.TestHelper) {
+	t.T().Helper()
+	oc.DeleteFile(t, a.ns, examples.EchoV2YamlFile())
+}
+
+func (a *echoV2) WaitReady(t test.TestHelper) {
+	t.T().Helper()
+	oc.WaitDeploymentRolloutComplete(t, a.ns, "tcp-echo-v2")
+}

--- a/pkg/app/echo.go
+++ b/pkg/app/echo.go
@@ -1,0 +1,54 @@
+// Copyright 2023 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"github.com/maistra/maistra-test-tool/pkg/examples"
+	"github.com/maistra/maistra-test-tool/pkg/util/oc"
+	"github.com/maistra/maistra-test-tool/pkg/util/test"
+)
+
+type echo struct {
+	ns string
+}
+
+var _ App = &echo{}
+
+func Echo(ns string) App {
+	return &echo{ns: ns}
+}
+
+func (a *echo) Name() string {
+	return "echo"
+}
+
+func (a *echo) Namespace() string {
+	return a.ns
+}
+
+func (a *echo) Install(t test.TestHelper) {
+	t.T().Helper()
+	oc.ApplyFile(t, a.ns, examples.EchoYamlFile())
+}
+
+func (a *echo) Uninstall(t test.TestHelper) {
+	t.T().Helper()
+	oc.DeleteFile(t, a.ns, examples.EchoYamlFile())
+}
+
+func (a *echo) WaitReady(t test.TestHelper) {
+	t.T().Helper()
+	oc.WaitDeploymentRolloutComplete(t, a.ns, "tcp-echo")
+}

--- a/pkg/examples/yaml_vars.go
+++ b/pkg/examples/yaml_vars.go
@@ -43,6 +43,8 @@ var (
 
 	echoYaml      = fmt.Sprintf("%s/%s/tcp-echo/tcp-echo-services.yaml", basedir, branch)
 	echoWithProxy = fmt.Sprintf("%s/%s/tcp-echo/tcp-echo.yaml", basedir, branch)
+	echov1Yaml    = fmt.Sprintf("%s/%s/tcp-echo/tcp-echo-v1.yaml", basedir, branch)
+	echov2Yaml    = fmt.Sprintf("%s/%s/tcp-echo/tcp-echo-v2.yaml", basedir, branch)
 
 	fortioYaml = fmt.Sprintf("%s/%s/httpbin/sample-client/fortio-deploy.yaml", basedir, branch)
 
@@ -66,6 +68,18 @@ var (
 )
 
 // TODO: remove these functions when the refactoring is done
+
+func EchoYamlFile() string {
+	return echoWithProxy
+}
+
+func EchoV1YamlFile() string {
+	return echov1Yaml
+}
+
+func EchoV2YamlFile() string {
+	return echov2Yaml
+}
 
 func HttpbinYamlFile() string {
 	return httpbinYaml

--- a/pkg/tests/tasks/security/authorization/tcp_test.go
+++ b/pkg/tests/tasks/security/authorization/tcp_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Red Hat, Inc.
+// Copyright 2023 Red Hat, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,156 +16,195 @@ package authorization
 
 import (
 	"fmt"
-	"strings"
 	"testing"
-	"time"
 
-	"github.com/maistra/maistra-test-tool/pkg/examples"
-	"github.com/maistra/maistra-test-tool/pkg/util"
-	"github.com/maistra/maistra-test-tool/pkg/util/log"
+	"github.com/maistra/maistra-test-tool/pkg/app"
+	"github.com/maistra/maistra-test-tool/pkg/util/check/assert"
+	"github.com/maistra/maistra-test-tool/pkg/util/hack"
+	"github.com/maistra/maistra-test-tool/pkg/util/oc"
+	"github.com/maistra/maistra-test-tool/pkg/util/pod"
+	"github.com/maistra/maistra-test-tool/pkg/util/retry"
 	"github.com/maistra/maistra-test-tool/pkg/util/test"
 )
 
-func cleanupAuthorTCP() {
-	log.Log.Info("Cleanup")
-	util.KubeDeleteContents("foo", TCPDenyGETPolicy)
-	util.KubeDeleteContents("foo", TCPAllowGETPolicy)
-	util.KubeDeleteContents("foo", TCPAllowPolicy)
-	echo := examples.Echo{Namespace: "foo"}
-	echo.UninstallWithProxy()
-	sleep := examples.Sleep{Namespace: "foo"}
-	sleep.Uninstall()
-	time.Sleep(time.Duration(20) * time.Second)
-}
+// TestAuthorizationTCPTraffic validates authorization polices for TCP traffic.
+func TestAuthorizationTCPTraffic(t *testing.T) {
+	test.NewTest(t).Id("T21").Groups(test.Full, test.InterOp).Run(func(t test.TestHelper) {
+		hack.DisableLogrusForThisTest(t)
 
-func TestAuthorTCP(t *testing.T) {
-	test.NewTest(t).Id("T21").Groups(test.Full, test.InterOp).NotRefactoredYet()
+		ns := "foo"
+		t.Cleanup(func() {
+			oc.RecreateNamespace(t, ns)
+		})
 
-	defer cleanupAuthorTCP()
-	defer util.RecoverPanic(t)
+		t.Log("This test validates authorization policies for TCP traffic.")
+		t.Log("Doc reference: https://istio.io/v1.14/docs/tasks/security/authorization/authz-tcp/")
 
-	log.Log.Info("Authorization for TCP traffic")
-	sleep := examples.Sleep{Namespace: "foo"}
-	sleep.Install()
-	echo := examples.Echo{Namespace: "foo"}
-	echo.InstallWithProxy()
-	time.Sleep(time.Duration(20) * time.Second)
+		t.LogStep("Install sleep and echo")
+		app.InstallAndWaitReady(t, app.Sleep(ns), app.Echo(ns))
 
-	log.Log.Info("Verify echo hello port")
-	sleepPod, err := util.GetPodName("foo", "app=sleep")
-	util.Inspect(err, "Failed to get sleep pod name", "", t)
-	ports := []string{"9000", "9001", "9002"}
-	for _, port := range ports {
-		if port == "9000" || port == "9001" {
-			cmd := fmt.Sprintf(`sh -c 'echo "port %s" | nc tcp-echo %s' | grep "hello" && echo 'connection succeeded' || echo 'connection rejected'`, port, port)
-			msg, err := util.PodExec("foo", sleepPod, "sleep", cmd, true)
-			util.Inspect(err, "Failed to get response", "", t)
-			if !strings.Contains(msg, "connection succeeded") {
-				log.Log.Errorf("Verify setup Unexpected response: %s", msg)
-				t.Errorf("Verify setup Unexpected response: %s", msg)
-			} else {
-				log.Log.Infof("Success. Get expected response: %s", msg)
-			}
-		} else {
-			tcpEchoPod, _ := util.GetPodName("foo", "app=tcp-echo")
-			podIP, _ := util.Shell(`kubectl get pod %s -n foo -o jsonpath="{.status.podIP}"`, tcpEchoPod)
-			cmd := fmt.Sprintf(`sh -c 'echo "port %s" | nc %s %s' | grep "hello" && echo 'connection succeeded' || echo 'connection rejected'`, port, podIP, port)
-			msg, err := util.PodExec("foo", sleepPod, "sleep", cmd, true)
-			util.Inspect(err, "Failed to get response", "", t)
-			if !strings.Contains(msg, "connection succeeded") {
-				log.Log.Errorf("Verify setup Unexpected response: %s", msg)
-				t.Errorf("Verify setup Unexpected response: %s", msg)
-			} else {
-				log.Log.Infof("Success. Get expected response: %s", msg)
-			}
-		}
-	}
+		t.LogStep("Verify sleep to echo TCP connections")
+		retry.UntilSuccess(t, func(t test.TestHelper) {
+			assertPortTcpEchoAccepted(t, ns, "9000")
+			assertPortTcpEchoAccepted(t, ns, "9001")
+		})
 
-	t.Run("Security_authorization_rbac_allow_GET_tcp", func(t *testing.T) {
-		defer util.RecoverPanic(t)
+		retry.UntilSuccess(t, func(t test.TestHelper) {
+			assertPortTcpEchoIPAccepted(t, ns, "9002")
+		})
 
-		log.Log.Info("Apply a policy to allow requests to port 9000 and 9001")
-		util.KubeApplyContents("foo", TCPAllowPolicy)
-		time.Sleep(time.Duration(10) * time.Second)
+		t.NewSubTest("TCP ALLOW policy").Run(func(t test.TestHelper) {
+			t.Cleanup(func() {
+				oc.DeleteFromString(t, ns, TCPAllowPolicy)
+			})
+			t.LogStep("Apply a policy to allow tcp requests to port 9000 and 9001")
+			oc.ApplyString(t, ns, TCPAllowPolicy)
 
-		ports := []string{"9000", "9001", "9002"}
-		for _, port := range ports {
-			if port == "9000" || port == "9001" {
-				cmd := fmt.Sprintf(`sh -c 'echo "port %s" | nc tcp-echo %s' | grep "hello" && echo 'connection succeeded' || echo 'connection rejected'`, port, port)
-				msg, err := util.PodExec("foo", sleepPod, "sleep", cmd, true)
-				util.Inspect(err, "Failed to get response", "", t)
-				if !strings.Contains(msg, "connection succeeded") {
-					log.Log.Errorf("Verify allow GET Unexpected response: %s", msg)
-					t.Errorf("Verify allow GET Unexpected response: %s", msg)
-				} else {
-					log.Log.Infof("Success. Get expected response: %s", msg)
-				}
-			} else {
-				tcpEchoPod, _ := util.GetPodName("foo", "app=tcp-echo")
-				podIP, _ := util.Shell(`kubectl get pod %s -n foo -o jsonpath="{.status.podIP}"`, tcpEchoPod)
-				cmd := fmt.Sprintf(`sh -c 'echo "port %s" | nc %s %s' | grep "hello" && echo 'connection succeeded' || echo 'connection rejected'`, port, podIP, port)
-				msg, err := util.PodExec("foo", sleepPod, "sleep", cmd, true)
-				util.Inspect(err, "Failed to get response", "", t)
-				if !strings.Contains(msg, "connection rejected") {
-					log.Log.Errorf("Verify allow GET Unexpected response: %s", msg)
-					t.Errorf("Verify allow GET Unexpected response: %s", msg)
-				} else {
-					log.Log.Infof("Success. Get expected response: %s", msg)
-				}
-			}
-		}
-	})
+			retry.UntilSuccess(t, func(t test.TestHelper) {
+				assertPortTcpEchoAccepted(t, ns, "9000")
+				assertPortTcpEchoAccepted(t, ns, "9001")
+			})
 
-	t.Run("Security_authorization_rbac_invalid_policy_tcp", func(t *testing.T) {
-		defer util.RecoverPanic(t)
+			retry.UntilSuccess(t, func(t test.TestHelper) {
+				assertPortTcpEchoIPDenied(t, ns, "9002")
+			})
+		})
 
-		log.Log.Info("Apply a policy to allow requests to port 9000 and add an HTTP GET field")
-		util.KubeApplyContents("foo", TCPAllowGETPolicy)
-		time.Sleep(time.Duration(10) * time.Second)
+		t.NewSubTest("TCP invalid policy").Run(func(t test.TestHelper) {
+			t.Cleanup(func() {
+				oc.DeleteFromString(t, ns, TCPAllowGETPolicy)
+			})
+			t.LogStep("Apply an invalid policy to allow requests to port 9000 and add an HTTP GET field")
+			oc.ApplyString(t, ns, TCPAllowGETPolicy)
 
-		ports := []string{"9000", "9001"}
-		for _, port := range ports {
-			cmd := fmt.Sprintf(`sh -c 'echo "port %s" | nc tcp-echo %s' | grep "hello" && echo 'connection succeeded' || echo 'connection rejected'`, port, port)
-			msg, err := util.PodExec("foo", sleepPod, "sleep", cmd, true)
-			util.Inspect(err, "Failed to get response", "", t)
-			if !strings.Contains(msg, "connection rejected") {
-				log.Log.Errorf("Verify invalid rule Unexpected response: %s", msg)
-				t.Errorf("Verify invalid rule Unexpected response: %s", msg)
-			} else {
-				log.Log.Infof("Success. Get expected response: %s", msg)
-			}
-		}
-	})
+			retry.UntilSuccess(t, func(t test.TestHelper) {
+				assertPortTcpEchoDenied(t, ns, "9000")
+				assertPortTcpEchoDenied(t, ns, "9001")
+			})
+		})
 
-	t.Run("Security_authorization_rbac_deny_GET_tcp", func(t *testing.T) {
-		defer util.RecoverPanic(t)
+		t.NewSubTest("TCP deny policy").Run(func(t test.TestHelper) {
+			t.Cleanup(func() {
+				oc.DeleteFromString(t, ns, TCPDenyGETPolicy)
+			})
+			t.LogStep("Apply a policy to deny tcp requests to port 9000")
+			oc.ApplyString(t, ns, TCPDenyGETPolicy)
 
-		log.Log.Info("Apply a DENY policy")
-		util.KubeApplyContents("foo", TCPDenyGETPolicy)
-		time.Sleep(time.Duration(10) * time.Second)
-
-		ports := []string{"9000", "9001"}
-		for _, port := range ports {
-			cmd := fmt.Sprintf(`sh -c 'echo "port %s" | nc tcp-echo %s' | grep "hello" && echo 'connection succeeded' || echo 'connection rejected'`, port, port)
-			msg, err := util.PodExec("foo", sleepPod, "sleep", cmd, true)
-			util.Inspect(err, "Failed to get response", "", t)
-
-			if port == "9000" {
-				if !strings.Contains(msg, "connection rejected") {
-					log.Log.Errorf("Verify DENY rule Unexpected response: %s", msg)
-					t.Errorf("Verify DENY rule Unexpected response: %s", msg)
-				} else {
-					log.Log.Infof("Success. Get expected response: %s", msg)
-				}
-			}
-			if port == "9001" {
-				if !strings.Contains(msg, "connection succeeded") {
-					log.Log.Errorf("Verify DENY rule Unexpected response: %s", msg)
-					t.Errorf("Verify DENY rule Unexpected response: %s", msg)
-				} else {
-					log.Log.Infof("Success. Get expected response: %s", msg)
-				}
-			}
-		}
+			retry.UntilSuccess(t, func(t test.TestHelper) {
+				assertPortTcpEchoDenied(t, ns, "9000")
+				assertPortTcpEchoAccepted(t, ns, "9001")
+			})
+		})
 	})
 }
+
+func assertPortTcpEchoAccepted(t test.TestHelper, ns string, port string) {
+	cmd := fmt.Sprintf(`sh -c 'echo "port %s" | nc tcp-echo %s' | grep "hello" && echo 'connection succeeded' || echo 'connection rejected'`,
+		port, port)
+	oc.Exec(t,
+		pod.MatchingSelector("app=sleep", ns),
+		"sleep",
+		cmd,
+		assert.OutputContains(
+			"connection succeeded",
+			fmt.Sprintf("Got expected hello message on port %s", port),
+			fmt.Sprintf("Expected return message hello, but failed on port %s", port)))
+}
+
+func assertPortTcpEchoDenied(t test.TestHelper, ns string, port string) {
+	cmd := fmt.Sprintf(`sh -c 'echo "port %s" | nc tcp-echo %s' | grep "hello" && echo 'connection succeeded' || echo 'connection rejected'`,
+		port, port)
+	oc.Exec(t,
+		pod.MatchingSelector("app=sleep", ns),
+		"sleep",
+		cmd,
+		assert.OutputContains(
+			"connection rejected",
+			fmt.Sprintf("Got expected connection rejected on port %s", port),
+			fmt.Sprintf("Expected connection rejected, but got return message hello on port %s", port)))
+}
+
+func assertPortTcpEchoIPAccepted(t test.TestHelper, ns string, port string) {
+	podIP := oc.GetPodIP(t,
+		pod.MatchingSelector("app=tcp-echo", ns))
+	cmd := fmt.Sprintf(`sh -c 'echo "port %s" | nc %s %s' | grep "hello" && echo 'connection succeeded' || echo 'connection rejected'`,
+		port, podIP, port)
+	oc.Exec(t,
+		pod.MatchingSelector("app=sleep", ns),
+		"sleep",
+		cmd,
+		assert.OutputContains(
+			"connection succeeded",
+			fmt.Sprintf("Got expected hello message on port %s", port),
+			fmt.Sprintf("Expected return message hello, but failed on port %s", port)))
+}
+
+func assertPortTcpEchoIPDenied(t test.TestHelper, ns string, port string) {
+	podIP := oc.GetPodIP(t,
+		pod.MatchingSelector("app=tcp-echo", ns))
+	cmd := fmt.Sprintf(`sh -c 'echo "port %s" | nc %s %s' | grep "hello" && echo 'connection succeeded' || echo 'connection rejected'`,
+		port, podIP, port)
+	oc.Exec(t,
+		pod.MatchingSelector("app=sleep", ns),
+		"sleep",
+		cmd,
+		assert.OutputContains(
+			"connection rejected",
+			fmt.Sprintf("Got expected connection rejected on port %s", port),
+			fmt.Sprintf("Expected connection rejected, but got return message hello on port %s", port)))
+}
+
+const (
+	TCPAllowPolicy = `
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: tcp-policy
+  namespace: foo
+spec:
+  selector:
+    matchLabels:
+      app: tcp-echo
+  action: ALLOW
+  rules:
+  - to:
+    - operation:
+       ports: ["9000", "9001"]
+`
+
+	TCPAllowGETPolicy = `
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: tcp-policy
+  namespace: foo
+spec:
+  selector:
+    matchLabels:
+      app: tcp-echo
+  action: ALLOW
+  rules:
+  - to:
+    - operation:
+        methods: ["GET"]
+        ports: ["9000"]
+`
+
+	TCPDenyGETPolicy = `
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: tcp-policy
+  namespace: foo
+spec:
+  selector:
+    matchLabels:
+      app: tcp-echo
+  action: DENY
+  rules:
+  - to:
+    - operation:
+        methods: ["GET"]
+        ports: ["9000"]
+`
+)

--- a/pkg/tests/tasks/security/authorization/tcp_test.go
+++ b/pkg/tests/tasks/security/authorization/tcp_test.go
@@ -35,6 +35,7 @@ func TestAuthorizationTCPTraffic(t *testing.T) {
 		ns := "foo"
 		t.Cleanup(func() {
 			oc.RecreateNamespace(t, ns)
+			oc.RecreateNamespace(t, meshNamespace)
 		})
 
 		t.Log("This test validates authorization policies for TCP traffic.")
@@ -99,12 +100,11 @@ func TestAuthorizationTCPTraffic(t *testing.T) {
 }
 
 func assertPortTcpEchoAccepted(t test.TestHelper, ns string, port string) {
-	cmd := fmt.Sprintf(`sh -c 'echo "port %s" | nc tcp-echo %s' | grep "hello" && echo 'connection succeeded' || echo 'connection rejected'`,
-		port, port)
 	oc.Exec(t,
 		pod.MatchingSelector("app=sleep", ns),
 		"sleep",
-		cmd,
+		fmt.Sprintf(`sh -c 'echo "port %s" | nc tcp-echo %s' | grep "hello" && echo 'connection succeeded' || echo 'connection rejected'`,
+			port, port),
 		assert.OutputContains(
 			"connection succeeded",
 			fmt.Sprintf("Got expected hello message on port %s", port),
@@ -112,12 +112,11 @@ func assertPortTcpEchoAccepted(t test.TestHelper, ns string, port string) {
 }
 
 func assertPortTcpEchoDenied(t test.TestHelper, ns string, port string) {
-	cmd := fmt.Sprintf(`sh -c 'echo "port %s" | nc tcp-echo %s' | grep "hello" && echo 'connection succeeded' || echo 'connection rejected'`,
-		port, port)
 	oc.Exec(t,
 		pod.MatchingSelector("app=sleep", ns),
 		"sleep",
-		cmd,
+		fmt.Sprintf(`sh -c 'echo "port %s" | nc tcp-echo %s' | grep "hello" && echo 'connection succeeded' || echo 'connection rejected'`,
+			port, port),
 		assert.OutputContains(
 			"connection rejected",
 			fmt.Sprintf("Got expected connection rejected on port %s", port),
@@ -127,12 +126,12 @@ func assertPortTcpEchoDenied(t test.TestHelper, ns string, port string) {
 func assertPortTcpEchoIPAccepted(t test.TestHelper, ns string, port string) {
 	podIP := oc.GetPodIP(t,
 		pod.MatchingSelector("app=tcp-echo", ns))
-	cmd := fmt.Sprintf(`sh -c 'echo "port %s" | nc %s %s' | grep "hello" && echo 'connection succeeded' || echo 'connection rejected'`,
-		port, podIP, port)
+
 	oc.Exec(t,
 		pod.MatchingSelector("app=sleep", ns),
 		"sleep",
-		cmd,
+		fmt.Sprintf(`sh -c 'echo "port %s" | nc %s %s' | grep "hello" && echo 'connection succeeded' || echo 'connection rejected'`,
+			port, podIP, port),
 		assert.OutputContains(
 			"connection succeeded",
 			fmt.Sprintf("Got expected hello message on port %s", port),
@@ -142,12 +141,12 @@ func assertPortTcpEchoIPAccepted(t test.TestHelper, ns string, port string) {
 func assertPortTcpEchoIPDenied(t test.TestHelper, ns string, port string) {
 	podIP := oc.GetPodIP(t,
 		pod.MatchingSelector("app=tcp-echo", ns))
-	cmd := fmt.Sprintf(`sh -c 'echo "port %s" | nc %s %s' | grep "hello" && echo 'connection succeeded' || echo 'connection rejected'`,
-		port, podIP, port)
+
 	oc.Exec(t,
 		pod.MatchingSelector("app=sleep", ns),
 		"sleep",
-		cmd,
+		fmt.Sprintf(`sh -c 'echo "port %s" | nc %s %s' | grep "hello" && echo 'connection succeeded' || echo 'connection rejected'`,
+			port, podIP, port),
 		assert.OutputContains(
 			"connection rejected",
 			fmt.Sprintf("Got expected connection rejected on port %s", port),

--- a/pkg/tests/tasks/security/authorization/yaml_configs.go
+++ b/pkg/tests/tasks/security/authorization/yaml_configs.go
@@ -36,59 +36,6 @@ spec:
       app: httpbin
 `
 
-	TCPAllowPolicy = `
-apiVersion: security.istio.io/v1beta1
-kind: AuthorizationPolicy
-metadata:
-  name: tcp-policy
-  namespace: foo
-spec:
-  selector:
-    matchLabels:
-      app: tcp-echo
-  action: ALLOW
-  rules:
-  - to:
-    - operation:
-       ports: ["9000", "9001"]
-`
-
-	TCPAllowGETPolicy = `
-apiVersion: security.istio.io/v1beta1
-kind: AuthorizationPolicy
-metadata:
-  name: tcp-policy
-  namespace: foo
-spec:
-  selector:
-    matchLabels:
-      app: tcp-echo
-  action: ALLOW
-  rules:
-  - to:
-    - operation:
-        methods: ["GET"]
-        ports: ["9000"]
-`
-
-	TCPDenyGETPolicy = `
-apiVersion: security.istio.io/v1beta1
-kind: AuthorizationPolicy
-metadata:
-  name: tcp-policy
-  namespace: foo
-spec:
-  selector:
-    matchLabels:
-      app: tcp-echo
-  action: DENY
-  rules:
-  - to:
-    - operation:
-        methods: ["GET"]
-        ports: ["9000"]
-`
-
 	JWTExampleRule = `
 apiVersion: "security.istio.io/v1beta1"
 kind: "RequestAuthentication"

--- a/pkg/util/oc/pod_commands.go
+++ b/pkg/util/oc/pod_commands.go
@@ -26,6 +26,13 @@ func Exec(t test.TestHelper, podLocator PodLocatorFunc, container string, cmd st
 		checks...)
 }
 
+func GetPodIP(t test.TestHelper, podLocator PodLocatorFunc) string {
+	t.T().Helper()
+	pod := podLocator(t)
+	return shell.Execute(t,
+		fmt.Sprintf("kubectl get pod -n %s %s -o jsonpath='{.status.podIP}'", pod.Namespace, pod.Name))
+}
+
 func MergePatch(t test.TestHelper, ns string, rs string, ptype string, patch string, checks ...assert.CheckFunc) {
 	t.T().Helper()
 	shell.Execute(t,

--- a/testdata/examples/x86/tcp-echo/tcp-echo-v1.yaml
+++ b/testdata/examples/x86/tcp-echo/tcp-echo-v1.yaml
@@ -1,0 +1,55 @@
+# Copyright 2018 Istio Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: tcp-echo
+  labels:
+    app: tcp-echo
+spec:
+  ports:
+  - name: tcp
+    port: 9000
+  #- name: tcp-other
+  #  port: 9001
+  ## Port 9002 is omitted intentionally for testing the pass through filter chain.
+  selector:
+    app: tcp-echo
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tcp-echo-v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tcp-echo
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: tcp-echo
+        version: v1
+    spec:
+      containers:
+      - name: tcp-echo
+        image: docker.io/istio/tcp-echo-server:1.2
+        imagePullPolicy: IfNotPresent
+        #args: [ "9000,9001,9002", "one" ]
+        args: [ "9000", "one" ]
+        ports:
+        - containerPort: 9000
+        #- containerPort: 9001

--- a/testdata/examples/x86/tcp-echo/tcp-echo-v2.yaml
+++ b/testdata/examples/x86/tcp-echo/tcp-echo-v2.yaml
@@ -1,0 +1,55 @@
+# Copyright 2018 Istio Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: tcp-echo
+  labels:
+    app: tcp-echo
+spec:
+  ports:
+  - name: tcp
+    port: 9000
+  #- name: tcp-other
+  #  port: 9001
+  ## Port 9002 is omitted intentionally for testing the pass through filter chain.
+  selector:
+    app: tcp-echo
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tcp-echo-v2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tcp-echo
+      version: v2
+  template:
+    metadata:
+      labels:
+        app: tcp-echo
+        version: v2
+    spec:
+      containers:
+      - name: tcp-echo
+        image: docker.io/istio/tcp-echo-server:1.2
+        imagePullPolicy: IfNotPresent
+        #args: [ "9000,9001,9002", "two" ]
+        args: [ "9000", "two" ]
+        ports:
+        - containerPort: 9000
+        #- containerPort: 9001


### PR DESCRIPTION
This PR includes:
- Refactor T21 TestAuthorizationTCPTraffic
- Refactor tcp-echo exaple app go code and yaml manifests . They will be used in the T4 test TCP traffic shifting refactoring next.
