### PR TITLE
OSSM-3741 Refactor TestRateLimiting T28

### DIFF
--- a/pkg/app/redis.go
+++ b/pkg/app/redis.go
@@ -1,0 +1,43 @@
+package app
+
+import (
+	"github.com/maistra/maistra-test-tool/pkg/examples"
+	"github.com/maistra/maistra-test-tool/pkg/util/oc"
+	"github.com/maistra/maistra-test-tool/pkg/util/test"
+)
+
+type redis struct {
+	ns string
+}
+
+var _ App = &bookinfo{}
+
+func Redis(ns string) App {
+	return &redis{ns: ns}
+}
+
+func (a *redis) Name() string {
+	return "redis"
+}
+
+func (a *redis) Namespace() string {
+	return a.ns
+}
+
+func (a *redis) Install(t test.TestHelper) {
+	t.T().Helper()
+	oc.CreateNamespace(t, a.ns)
+	t.Log("Deploy Redis in namespace %q", a.ns)
+	oc.ApplyFile(t, a.ns, examples.RedisYamlFile())
+}
+
+func (a *redis) Uninstall(t test.TestHelper) {
+	t.T().Helper()
+	t.Logf("Uninstalling Redis from namespace %q", a.ns)
+	oc.DeleteFile(t, a.ns, examples.RedisYamlFile())
+}
+
+func (a *redis) WaitReady(t test.TestHelper) {
+	t.T().Helper()
+	oc.WaitDeploymentRolloutComplete(t, a.ns, "redis")
+}

--- a/pkg/app/redis.go
+++ b/pkg/app/redis.go
@@ -10,7 +10,7 @@ type redis struct {
 	ns string
 }
 
-var _ App = &bookinfo{}
+var _ App = &redis{}
 
 func Redis(ns string) App {
 	return &redis{ns: ns}

--- a/pkg/app/redis.go
+++ b/pkg/app/redis.go
@@ -33,7 +33,7 @@ func (a *redis) Install(t test.TestHelper) {
 
 func (a *redis) Uninstall(t test.TestHelper) {
 	t.T().Helper()
-	t.Logf("Uninstalling Redis from namespace %q", a.ns)
+	t.Logf("Uninstall Redis from namespace %q", a.ns)
 	oc.DeleteFile(t, a.ns, examples.RedisYamlFile())
 }
 

--- a/pkg/examples/yaml_vars.go
+++ b/pkg/examples/yaml_vars.go
@@ -120,3 +120,7 @@ func BookinfoRuleAllYamlFile() string {
 func BookinfoRuleAllMTLSYamlFile() string {
 	return bookinfoRuleAllTLSYaml
 }
+
+func RedisYamlFile() string {
+	return redisYaml
+}

--- a/pkg/tests/ossm/ratelimit_test.go
+++ b/pkg/tests/ossm/ratelimit_test.go
@@ -43,7 +43,8 @@ var (
 func TestRateLimiting(t *testing.T) {
 	NewTest(t).Id("T28").Groups(Full).Run(func(t TestHelper) {
 		hack.DisableLogrusForThisTest(t)
-		skip := env.SMCPVersionLessThan("2.2")
+		const version22 = parseVersion("2.2")   // this should somewhere at the top of the file (actually, it should be in a different file altogether)
+		skip := env.GetSMCPVersion().LessThan(version22)
 		if skip {
 			t.T().Skip("Rate limiting is not supported for SMCP versions v2.3+")
 		}

--- a/pkg/tests/ossm/ratelimit_test.go
+++ b/pkg/tests/ossm/ratelimit_test.go
@@ -65,7 +65,7 @@ func TestRateLimiting(t *testing.T) {
 		retry.UntilSuccess(t, func(t test.TestHelper) {
 			curl.Request(t, productPageURL, nil, assert.ResponseStatus(200))
 			curl.Request(t, productPageURL, nil, assert.ResponseStatus(429))
-			time.Sleep(time.Second * 20)
+			time.Sleep(time.Second * 5)
 			curl.Request(t, productPageURL, nil, assert.ResponseStatus(200))
 		})
 	})

--- a/pkg/tests/ossm/ratelimit_test.go
+++ b/pkg/tests/ossm/ratelimit_test.go
@@ -43,8 +43,8 @@ var (
 func TestRateLimiting(t *testing.T) {
 	NewTest(t).Id("T28").Groups(Full).Run(func(t TestHelper) {
 		hack.DisableLogrusForThisTest(t)
-		const version22 = parseVersion("2.2")   // this should somewhere at the top of the file (actually, it should be in a different file altogether)
-		skip := env.GetSMCPVersion().LessThan(version22)
+		supportedV := env.Version{Major: 2, Minor: 2}
+		skip := env.GetSMCPVersion().LessThan(supportedV)
 		if skip {
 			t.T().Skip("Rate limiting is not supported for SMCP versions v2.3+")
 		}
@@ -85,4 +85,8 @@ func TestRateLimiting(t *testing.T) {
 			curl.Request(t, productPageURL, nil, assert.ResponseStatus(200))
 		})
 	})
+}
+
+func parseVersion(s string) {
+	panic("unimplemented")
 }

--- a/pkg/tests/ossm/ratelimit_test.go
+++ b/pkg/tests/ossm/ratelimit_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/shell"
 	"github.com/maistra/maistra-test-tool/pkg/util/test"
 	. "github.com/maistra/maistra-test-tool/pkg/util/test"
+	"github.com/maistra/maistra-test-tool/pkg/util/version"
 )
 
 var (
@@ -43,9 +44,7 @@ var (
 func TestRateLimiting(t *testing.T) {
 	NewTest(t).Id("T28").Groups(Full).Run(func(t TestHelper) {
 		hack.DisableLogrusForThisTest(t)
-		supportedV := env.Version{Major: 2, Minor: 2}
-		skip := env.GetSMCPVersion().LessThan(supportedV)
-		if skip {
+		if env.GetSMCPVersion().GreaterThanOrEqualTo(version.SMCP_2_3) {
 			t.T().Skip("Rate limiting is not supported for SMCP versions v2.3+")
 		}
 
@@ -85,8 +84,4 @@ func TestRateLimiting(t *testing.T) {
 			curl.Request(t, productPageURL, nil, assert.ResponseStatus(200))
 		})
 	})
-}
-
-func parseVersion(s string) {
-	panic("unimplemented")
 }

--- a/pkg/tests/ossm/yaml/smcp-patch-rate-limiting.yaml
+++ b/pkg/tests/ossm/yaml/smcp-patch-rate-limiting.yaml
@@ -11,7 +11,7 @@ spec:
         - key: PATH
           value: "/productpage"
           rate_limit:
-            unit: minute
+            unit: second
             requests_per_unit: 1
         - key: PATH
           rate_limit:

--- a/pkg/util/env/env.go
+++ b/pkg/util/env/env.go
@@ -8,14 +8,11 @@ import (
 	"sync"
 
 	"github.com/joho/godotenv"
+
+	"github.com/maistra/maistra-test-tool/pkg/util/version"
 )
 
 var initEnvVarsOnce sync.Once
-
-type Version struct {
-	Major int
-	Minor int
-}
 
 // getenv loads test.env file and returns an environment variable value.
 // If the environment variable is empty, it returns the fallback as a default value.
@@ -75,37 +72,10 @@ func GetDefaultSMCPVersion() string {
 	return Getenv("SMCPVERSION", "2.4")
 }
 
-func GetSMCPVersion() Version {
-	return parseVersion(GetDefaultSMCPVersion())
+func GetSMCPVersion() version.Version {
+	return version.ParseVersion(GetDefaultSMCPVersion())
 }
 
 func GetOperatorNamespace() string {
 	return "openshift-operators"
-}
-
-func (testingVersion Version) LessThan(supportedVersion Version) bool {
-	if testingVersion.Major < supportedVersion.Major {
-		return false
-	}
-	if testingVersion.Major > supportedVersion.Major {
-		return true
-	}
-	return testingVersion.Minor > supportedVersion.Minor
-}
-
-func parseVersion(version string) Version {
-	majorMinor := strings.Split(version, ".")
-	if len(majorMinor) != 2 {
-		panic(fmt.Sprintf("invalid SMCP version: %s", version))
-	}
-	major, err := strconv.Atoi(majorMinor[0])
-	if err != nil {
-		panic(fmt.Sprintf("invalid SMCP version: %s", version))
-	}
-	minor, err := strconv.Atoi(majorMinor[1])
-	if err != nil {
-		panic(fmt.Sprintf("invalid SMCP version: %s", version))
-	}
-
-	return Version{Major: major, Minor: minor}
 }

--- a/pkg/util/env/env.go
+++ b/pkg/util/env/env.go
@@ -12,6 +12,11 @@ import (
 
 var initEnvVarsOnce sync.Once
 
+type Version struct {
+	major int
+	minor int
+}
+
 // getenv loads test.env file and returns an environment variable value.
 // If the environment variable is empty, it returns the fallback as a default value.
 func Getenv(key, fallback string) string {
@@ -72,4 +77,38 @@ func GetDefaultSMCPVersion() string {
 
 func GetOperatorNamespace() string {
 	return "openshift-operators"
+}
+
+func SMCPVersionLessThan(v string) bool {
+	if len(v) == 0 {
+		return false
+	}
+
+	testingVersion := splitVersion(GetDefaultSMCPVersion())
+	supportedVersion := splitVersion(v)
+
+	if testingVersion.major < supportedVersion.major {
+		return true
+	}
+	if testingVersion.major > supportedVersion.major {
+		return false
+	}
+	return testingVersion.minor < supportedVersion.minor
+}
+
+func splitVersion(version string) Version {
+	majorMinor := strings.Split(version, ".")
+	if len(majorMinor) != 2 {
+		panic(fmt.Sprintf("invalid SMCP version: %s", version))
+	}
+	major, err := strconv.Atoi(majorMinor[0])
+	if err != nil {
+		panic(fmt.Sprintf("invalid SMCP version: %s", version))
+	}
+	minor, err := strconv.Atoi(majorMinor[1])
+	if err != nil {
+		panic(fmt.Sprintf("invalid SMCP version: %s", version))
+	}
+
+	return Version{major: major, minor: minor}
 }

--- a/pkg/util/env/env.go
+++ b/pkg/util/env/env.go
@@ -79,7 +79,7 @@ func GetOperatorNamespace() string {
 	return "openshift-operators"
 }
 
-func SMCPVersionLessThan(v string) bool {
+func (v Version) LessThan(other Version) bool {
 	if len(v) == 0 {
 		return false
 	}

--- a/pkg/util/env/env.go
+++ b/pkg/util/env/env.go
@@ -96,7 +96,7 @@ func SMCPVersionLessThan(v string) bool {
 	return testingVersion.minor < supportedVersion.minor
 }
 
-func splitVersion(version string) Version {
+func parseVersion(version string) Version {
 	majorMinor := strings.Split(version, ".")
 	if len(majorMinor) != 2 {
 		panic(fmt.Sprintf("invalid SMCP version: %s", version))

--- a/pkg/util/env/env.go
+++ b/pkg/util/env/env.go
@@ -13,8 +13,8 @@ import (
 var initEnvVarsOnce sync.Once
 
 type Version struct {
-	major int
-	minor int
+	Major int
+	Minor int
 }
 
 // getenv loads test.env file and returns an environment variable value.
@@ -75,25 +75,22 @@ func GetDefaultSMCPVersion() string {
 	return Getenv("SMCPVERSION", "2.4")
 }
 
+func GetSMCPVersion() Version {
+	return parseVersion(GetDefaultSMCPVersion())
+}
+
 func GetOperatorNamespace() string {
 	return "openshift-operators"
 }
 
-func (v Version) LessThan(other Version) bool {
-	if len(v) == 0 {
+func (testingVersion Version) LessThan(supportedVersion Version) bool {
+	if testingVersion.Major < supportedVersion.Major {
 		return false
 	}
-
-	testingVersion := splitVersion(GetDefaultSMCPVersion())
-	supportedVersion := splitVersion(v)
-
-	if testingVersion.major < supportedVersion.major {
+	if testingVersion.Major > supportedVersion.Major {
 		return true
 	}
-	if testingVersion.major > supportedVersion.major {
-		return false
-	}
-	return testingVersion.minor < supportedVersion.minor
+	return testingVersion.Minor > supportedVersion.Minor
 }
 
 func parseVersion(version string) Version {
@@ -110,5 +107,5 @@ func parseVersion(version string) Version {
 		panic(fmt.Sprintf("invalid SMCP version: %s", version))
 	}
 
-	return Version{major: major, minor: minor}
+	return Version{Major: major, Minor: minor}
 }

--- a/pkg/util/version/version.go
+++ b/pkg/util/version/version.go
@@ -1,0 +1,54 @@
+package version
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+var (
+	SMCP_2_1 = ParseVersion("2.1")
+	SMCP_2_2 = ParseVersion("2.2")
+	SMCP_2_3 = ParseVersion("2.3")
+	SMCP_2_4 = ParseVersion("2.4")
+)
+
+type Version struct {
+	Major int
+	Minor int
+}
+
+func ParseVersion(version string) Version {
+	majorMinor := strings.Split(version, ".")
+	if len(majorMinor) != 2 {
+		panic(fmt.Sprintf("invalid SMCP version: %s", version))
+	}
+	major, err := strconv.Atoi(majorMinor[0])
+	if err != nil {
+		panic(fmt.Sprintf("invalid SMCP version: %s", version))
+	}
+	minor, err := strconv.Atoi(majorMinor[1])
+	if err != nil {
+		panic(fmt.Sprintf("invalid SMCP version: %s", version))
+	}
+
+	return Version{Major: major, Minor: minor}
+}
+
+func (this Version) GreaterThanOrEqualTo(that Version) bool {
+	return !this.LessThan(that)
+}
+
+func (this Version) LessThan(that Version) bool {
+	if this.Major < that.Major {
+		return true
+	} else if this.Major > that.Major {
+		return false
+	} else { // this.Major == that.Major
+		return this.Minor < that.Minor
+	}
+}
+
+func (this Version) String() string {
+	return fmt.Sprintf("%d.%d", this.Major, this.Minor)
+}

--- a/pkg/util/version/version_test.go
+++ b/pkg/util/version/version_test.go
@@ -1,0 +1,31 @@
+package version
+
+import "testing"
+
+func TestLessThan(t *testing.T) {
+	assertTrue(t, SMCP_2_1.LessThan(SMCP_2_2))
+	assertTrue(t, SMCP_2_1.LessThan(SMCP_2_3))
+	assertFalse(t, SMCP_2_1.LessThan(SMCP_2_1))
+	assertFalse(t, SMCP_2_2.LessThan(SMCP_2_1))
+}
+
+func TestGreaterThanOrEqual(t *testing.T) {
+	assertFalse(t, SMCP_2_1.GreaterThanOrEqualTo(SMCP_2_2))
+	assertFalse(t, SMCP_2_1.GreaterThanOrEqualTo(SMCP_2_3))
+	assertTrue(t, SMCP_2_1.GreaterThanOrEqualTo(SMCP_2_1))
+	assertTrue(t, SMCP_2_2.GreaterThanOrEqualTo(SMCP_2_1))
+}
+
+func assertTrue(t *testing.T, b bool) {
+	t.Helper()
+	if !b {
+		t.Errorf("expected true, but was false")
+	}
+}
+
+func assertFalse(t *testing.T, b bool) {
+	t.Helper()
+	if b {
+		t.Errorf("expected false, but was true")
+	}
+}


### PR DESCRIPTION
Jira ticket: https://issues.redhat.com/browse/OSSM-3741

Refactored the test case with these changes:
- Created redis.go to install Redis application with the new framework
- Changed the unit to allow requests with the rate limit feature
- Skip the test in v2.3+ 
Executed this test against OCP 4.13 and works with the new configuration