### PR TITLE
OSSM-3762 Refactor TestCircuitBreaking T6

### DIFF
--- a/pkg/app/fortio.go
+++ b/pkg/app/fortio.go
@@ -1,0 +1,40 @@
+package app
+
+import (
+	"github.com/maistra/maistra-test-tool/pkg/examples"
+	"github.com/maistra/maistra-test-tool/pkg/util/oc"
+	"github.com/maistra/maistra-test-tool/pkg/util/test"
+)
+
+type fortio struct {
+	ns string
+}
+
+var _ App = &fortio{}
+
+func Fortio(ns string) App {
+	return &fortio{ns: ns}
+}
+
+func (a *fortio) Name() string {
+	return "fortio"
+}
+
+func (a *fortio) Namespace() string {
+	return a.ns
+}
+
+func (a *fortio) Install(t test.TestHelper) {
+	t.T().Helper()
+	oc.ApplyFile(t, a.ns, examples.FortioYamlFile())
+}
+
+func (a *fortio) Uninstall(t test.TestHelper) {
+	t.T().Helper()
+	oc.DeleteFile(t, a.ns, examples.FortioYamlFile())
+}
+
+func (a *fortio) WaitReady(t test.TestHelper) {
+	t.T().Helper()
+	oc.WaitDeploymentRolloutComplete(t, a.ns, "fortio-deploy")
+}

--- a/pkg/examples/yaml_vars.go
+++ b/pkg/examples/yaml_vars.go
@@ -120,3 +120,7 @@ func BookinfoRuleAllYamlFile() string {
 func BookinfoRuleAllMTLSYamlFile() string {
 	return bookinfoRuleAllTLSYaml
 }
+
+func FortioYamlFile() string {
+	return fortioYaml
+}

--- a/pkg/tests/tasks/traffic/yaml_configs.go
+++ b/pkg/tests/tasks/traffic/yaml_configs.go
@@ -15,27 +15,6 @@
 package traffic
 
 const (
-	httpbinCircuitBreaker = `
-apiVersion: networking.istio.io/v1alpha3
-kind: DestinationRule
-metadata:
-  name: httpbin
-spec:
-  host: httpbin
-  trafficPolicy:
-    connectionPool:
-      tcp:
-        maxConnections: 1
-      http:
-        http1MaxPendingRequests: 1
-        maxRequestsPerConnection: 1
-    outlierDetection:
-      consecutiveErrors: 1
-      interval: 1s
-      baseEjectionTime: 3m
-      maxEjectionPercent: 100
-`
-
 	httpbinAllv1 = `
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService

--- a/pkg/util/oc/pod_commands.go
+++ b/pkg/util/oc/pod_commands.go
@@ -20,10 +20,10 @@ type NamespacedName struct {
 
 type PodLocatorFunc func(t test.TestHelper) NamespacedName
 
-func Exec(t test.TestHelper, podLocator PodLocatorFunc, container string, cmd string, checks ...common.CheckFunc) {
+func Exec(t test.TestHelper, podLocator PodLocatorFunc, container string, cmd string, checks ...common.CheckFunc) string {
 	t.T().Helper()
 	pod := podLocator(t)
-	shell.Execute(t,
+	return shell.Execute(t,
 		fmt.Sprintf("kubectl exec -n %s %s -c %s -- %s", pod.Namespace, pod.Name, container, cmd),
 		checks...)
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/OSSM-3762

Refactored this test case:

- Added fortio.go to be able to install fortio
- Create local func getNumberOfResponses to get the number of response from one response code of the body message from load test
- Added return string to pod.Exec to be able to get output from exec on pod
- Delete this entire section of the old test because we do not need anymore, is only getting stats but not doing anything with them
```go
log.Log.Info("Query the istio-proxy stats")
		command = fmt.Sprintf(`pilot-agent request GET stats | grep httpbin | grep pending`)
		msg, _ = util.PodExec("bookinfo", pod, "istio-proxy", command, false)
		log.Log.Infof("%s", msg)
```