### PR TITLE
OSSM-3669: updating dockerfile to make it work in OCP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,5 @@ WORKDIR $HOME/tests
 RUN chgrp -R 0 $GOPATH \
     && chmod -R g=u $GOPATH
 
-# ENTRYPOINT is not a shell, if you need export environment variables, use ["/bin/bash/", "-c", "scripts"]
-#ENTRYPOINT ["../scripts/pipeline/run_all_tests.sh"]
+# using CMD here so it can be easily overwritten when using this in OpenShiftCI
 CMD ["/bin/bash", "-c", "../scripts/pipeline/run_all_tests.sh"]

--- a/scripts/pipeline/create_smcp.sh
+++ b/scripts/pipeline/create_smcp.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+# This script creates a basic SMCP cr with given version in istio-system namespace.
+# SMCP_VERSION env variable is required
+# oc client is expected to be logged in
+
+smcp_namespace="istio-system"
+smcp_name="basic-smcp"
+
+if ! oc get namespace ${smcp_namespace}
+then
+  oc new-project ${smcp_namespace}
+
+  # wait for servicemeshoperator to be sucesfully installed in the newly created namespace
+  i=1
+  until oc get csv -n ${smcp_namespace} 2>&1 | grep servicemeshoperator | grep Succeeded
+  do
+    if [ $i -gt 10 ]
+    then
+      echo "Timeout waiting for servicemeshoperator installation"
+      exit 1
+    fi
+
+    echo "Waiting for servicemeshoperator installation"
+    sleep 10
+    ((i=i+1))
+  done
+
+  # workaround for https://issues.redhat.com/browse/OSSM-521
+  sleep 120
+fi
+
+oc apply -f - <<EOF
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+metadata:
+  name: ${smcp_name}
+  namespace: ${smcp_namespace}
+spec:
+  version: ${SMCP_VERSION}
+  security:
+    dataPlane:
+      mtls: true
+      automtls: true
+    controlPlane:
+      mtls: true
+  tracing:
+    type: Jaeger
+  addons:
+    jaeger:
+      install:
+        storage:
+          type: Memory
+    grafana:
+      enabled: true
+    kiali:
+      enabled: true
+    prometheus:
+      enabled: true
+EOF
+
+oc wait --for condition=Ready smcp/${smcp_name} -n ${smcp_namespace} --timeout=180s

--- a/scripts/pipeline/remove_smcp.sh
+++ b/scripts/pipeline/remove_smcp.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+# This script removes 'basic-smcp' from istio-system namespace and removes the namespace.
+# oc client is expected to be logged in
+
+smcp_namespace="istio-system"
+smcp_name="basic-smcp"
+
+oc delete smcp/${smcp_name} -n ${smcp_namespace} || true
+oc delete project ${smcp_namespace} || true
+# oc delete project does not wait for a namespace to be removed, we need to also call 'oc delete namespace'
+oc delete namespace ${smcp_namespace} || true

--- a/scripts/pipeline/run_all_tests.sh
+++ b/scripts/pipeline/run_all_tests.sh
@@ -9,7 +9,7 @@ then
 else
   oc login -u ${OCP_CRED_USR} -p ${OCP_CRED_PSW} --server=${OCP_API_URL} --insecure-skip-tls-verify=true
 fi
-go test -timeout 3h -v 2>&1 | tee >($HOME/go/bin/go-junit-report > results.xml) test.log
+go test -timeout 3h -v 2>&1 | tee >(go-junit-report > results.xml) test.log
 
 echo "#Testing Completed#"
 sleep 90

--- a/scripts/pipeline/run_one_test.sh
+++ b/scripts/pipeline/run_one_test.sh
@@ -9,7 +9,7 @@ then
 else
   oc login -u ${OCP_CRED_USR} -p ${OCP_CRED_PSW} --server=${OCP_API_URL} --insecure-skip-tls-verify=true
 fi
-go test -timeout 3h -run ${TEST_CASE} -v 2>&1 | tee >($HOME/go/bin/go-junit-report > results.xml) test.log
+go test -timeout 3h -run ${TEST_CASE} -v 2>&1 | tee >(go-junit-report > results.xml) test.log
 
 echo "#Testing Completed#"
 sleep 90


### PR DESCRIPTION
Those changes are required to be able to run the container in OCP. Also adding simple scripts for SMCP creation and removal.