### PR TITLE
Fix pod.MatchingSelector()

### DIFF
--- a/pkg/tests/ossm/initcontainer_test.go
+++ b/pkg/tests/ossm/initcontainer_test.go
@@ -42,7 +42,7 @@ func TestInitContainerNotRemovedDuringInjection(t *testing.T) {
 
 		t.LogStep("Deploying test pod.")
 		oc.ApplyString(t, ns, testInitContainerYAML)
-		oc.WaitPodReady(t, pod.MatchingSelector(podSelector, ns))
+		oc.WaitDeploymentRolloutComplete(t, ns, "sleep-init")
 
 		t.LogStep("Checking pod logs for init message.")
 		oc.Logs(t,

--- a/pkg/tests/tasks/traffic/ingress/secure_gateways_test.go
+++ b/pkg/tests/tasks/traffic/ingress/secure_gateways_test.go
@@ -26,7 +26,6 @@ import (
 	. "github.com/maistra/maistra-test-tool/pkg/util/env"
 	"github.com/maistra/maistra-test-tool/pkg/util/hack"
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
-	"github.com/maistra/maistra-test-tool/pkg/util/pod"
 	"github.com/maistra/maistra-test-tool/pkg/util/request"
 	"github.com/maistra/maistra-test-tool/pkg/util/retry"
 	. "github.com/maistra/maistra-test-tool/pkg/util/test"
@@ -65,7 +64,7 @@ func TestSecureGateways(t *testing.T) {
 
 		app.InstallAndWaitReady(t, app.Httpbin(ns))
 		oc.ApplyString(t, ns, helloWorldYAML())
-		oc.WaitPodReady(t, pod.MatchingSelector("app=helloworld-v1", ns))
+		oc.WaitDeploymentRolloutComplete(t, ns, "helloworld-v1")
 
 		t.LogStep("Create TLS secrets")
 		oc.CreateTLSSecret(t, meshNamespace, "httpbin-credential", httpbinSampleServerCertKey, httpbinSampleServerCert)

--- a/pkg/util/oc/pod_commands.go
+++ b/pkg/util/oc/pod_commands.go
@@ -18,6 +18,13 @@ type NamespacedName struct {
 	Name      string
 }
 
+func NewNamespacedName(ns, name string) NamespacedName {
+	return NamespacedName{
+		Namespace: ns,
+		Name:      name,
+	}
+}
+
 type PodLocatorFunc func(t test.TestHelper, oc *OC) NamespacedName
 
 func (o OC) Exec(t test.TestHelper, podLocator PodLocatorFunc, container string, cmd string, checks ...common.CheckFunc) string {

--- a/pkg/util/pod/pods.go
+++ b/pkg/util/pod/pods.go
@@ -11,19 +11,16 @@ func MatchingSelector(selector string, ns string) ocpackage.PodLocatorFunc {
 	return func(t test.TestHelper, oc *ocpackage.OC) ocpackage.NamespacedName {
 		t.T().Helper()
 		output := oc.Invokef(t, "kubectl -n %s get pods -l %q -o jsonpath='{.items[*].metadata.name}'", ns, selector)
-		pods := strings.Split(output, " ")
-		switch len(pods) {
-		case 0:
+		if output == "" {
 			t.Fatalf("no pods found using selector %s in namespace %s", selector, ns)
-		case 1:
-			return ocpackage.NamespacedName{
-				Namespace: ns,
-				Name:      pods[0],
-			}
-		default:
+		}
+		pods := strings.Split(output, " ")
+		if len(pods) == 1 {
+			return ocpackage.NewNamespacedName(ns, pods[0])
+		} else {
 			t.Fatalf("more than one pod found using selector %q in namespace %s: %v", selector, ns, pods)
+			panic("should never reach this point because the preceding code either returns or calls t.Fatalf(), which causes a panic")
 		}
 
-		panic("should never reach this point because the preceding code either returns or calls t.Fatalf(), which causes a panic")
 	}
 }


### PR DESCRIPTION
When pod didn't exist, the function returned an empty NamespacedName instead of failing. This caused some tests to fail.