### PR TITLE
Run TestSMCPAnnotations subtests in parallel

### DIFF
--- a/pkg/tests/ossm/smcp_annotation_test.go
+++ b/pkg/tests/ossm/smcp_annotation_test.go
@@ -34,9 +34,10 @@ func TestSMCPAnnotations(t *testing.T) {
 	NewTest(t).Id("T29").Groups(Full).Run(func(t TestHelper) {
 		t.Log("Test annotations: verify deployment with sidecar.maistra.io/proxyEnv annotations and Enable automatic injection in SMCP to propagate the annotations to the sidecar")
 		hack.DisableLogrusForThisTest(t)
-		ns := "foo"
 
 		t.NewSubTest("proxyEnvoy").Run(func(t TestHelper) {
+			t.Parallel()
+			ns := "foo"
 			t.Cleanup(func() {
 				oc.RecreateNamespace(t, ns)
 			})
@@ -51,6 +52,8 @@ func TestSMCPAnnotations(t *testing.T) {
 
 		// Test that the SMCP automatic injection with quotes works
 		t.NewSubTest("quote_injection").Run(func(t TestHelper) {
+			t.Parallel()
+			ns := "bar"
 			t.Cleanup(func() {
 				oc.RecreateNamespace(t, ns)
 			})

--- a/pkg/util/test/test_helper.go
+++ b/pkg/util/test/test_helper.go
@@ -42,6 +42,8 @@ type TestHelper interface {
 
 	T() *testing.T
 
+	Parallel()
+
 	WillRetry() bool
 }
 
@@ -171,6 +173,10 @@ func (t *testHelper) NewSubTest(name string) Test {
 
 func (t *testHelper) T() *testing.T {
 	return t.t
+}
+
+func (t *testHelper) Parallel() {
+	t.t.Parallel()
 }
 
 func (t *testHelper) WillRetry() bool {


### PR DESCRIPTION
This small change cuts the test duration in half (from 40s to 20s).