### PR TITLE
Ensure TestAuthorizationTCPTraffic doesn't break other tests

### DIFF
--- a/pkg/tests/tasks/security/authorization/tcp_test.go
+++ b/pkg/tests/tasks/security/authorization/tcp_test.go
@@ -35,7 +35,6 @@ func TestAuthorizationTCPTraffic(t *testing.T) {
 		ns := "foo"
 		t.Cleanup(func() {
 			oc.RecreateNamespace(t, ns)
-			oc.RecreateNamespace(t, meshNamespace)
 		})
 
 		t.Log("This test validates authorization policies for TCP traffic.")


### PR DESCRIPTION
The test recreated the mesh namespace (with no special reason), causing the next text to fail because the SMCP was missing.