### PR TITLE
Improve logging

### DIFF
--- a/pkg/util/retry/retry.go
+++ b/pkg/util/retry/retry.go
@@ -17,11 +17,6 @@ func UntilSuccessWithOptions(t test.TestHelper, options RetryOptions, f func(t t
 	for i := 0; i < options.maxAttempts; i++ {
 		lastAttempt := i == options.maxAttempts-1
 
-		if i > 0 && options.logAttempts {
-			t.Log()
-			t.Logf("Attempt %d/%d:", i+1, options.maxAttempts)
-		}
-
 		var attemptHelper test.TestHelper
 		if lastAttempt {
 			attemptHelper = t
@@ -40,9 +35,9 @@ func UntilSuccessWithOptions(t test.TestHelper, options RetryOptions, f func(t t
 			} else {
 				if options.logAttempts {
 					if options.delayBetweenAttempts == defaultOptions.delayBetweenAttempts {
-						t.Logf("Attempt %d/%d failed. Retrying...", i+1, options.maxAttempts)
+						t.Logf("--- Attempt %d/%d failed. Retrying...", i+1, options.maxAttempts)
 					} else {
-						t.Logf("Attempt %d/%d failed. Retrying in %v...", i+1, options.maxAttempts, options.delayBetweenAttempts)
+						t.Logf("--- Attempt %d/%d failed. Retrying in %v...", i+1, options.maxAttempts, options.delayBetweenAttempts)
 					}
 				}
 				time.Sleep(options.delayBetweenAttempts)
@@ -51,7 +46,7 @@ func UntilSuccessWithOptions(t test.TestHelper, options RetryOptions, f func(t t
 			if i > 0 && options.logAttempts {
 				// there was at least one failed attempt, so let's log the current attempt as successful so that
 				// the user isn't left wondering
-				t.Logf("Attempt %d/%d successful; total time: %.2fs", i+1, options.maxAttempts, time.Now().Sub(start).Seconds())
+				t.Logf("--- Attempt %d/%d successful; total time: %.2fs", i+1, options.maxAttempts, time.Now().Sub(start).Seconds())
 			}
 			if options.maxAttempts > 1 {
 				percentage := i * 100 / options.maxAttempts

--- a/pkg/util/test/subtest.go
+++ b/pkg/util/test/subtest.go
@@ -20,6 +20,7 @@ func (t subTest) Run(f func(t TestHelper)) {
 		ctx := NewTestContext(t)
 		start := time.Now()
 		f(ctx)
+		t.Log()
 		t.Logf("Subtest completed in %.2fs (excluding cleanup)", time.Now().Sub(start).Seconds())
 	})
 }

--- a/pkg/util/test/test.go
+++ b/pkg/util/test/test.go
@@ -60,6 +60,7 @@ func (t *topLevelTest) Run(f func(t TestHelper)) {
 	th := &testHelper{t: t.t}
 	disableLogrusForThisTest(th)
 	f(th)
+	t.t.Log()
 	t.t.Logf("Test completed in %.2fs (excluding cleanup)", time.Now().Sub(start).Seconds())
 }
 

--- a/pkg/util/test/test_helper.go
+++ b/pkg/util/test/test_helper.go
@@ -6,6 +6,11 @@ import (
 	"time"
 )
 
+const (
+	Success = "SUCCESS"
+	Failure = "FAILURE"
+)
+
 func NewTestContext(t *testing.T) TestHelper {
 	ctx := &testHelper{
 		t: t,
@@ -102,13 +107,13 @@ func (t *testHelper) Logf(format string, args ...any) {
 
 func (t *testHelper) Error(args ...any) {
 	t.t.Helper()
-	t.Log("ERROR: " + fmt.Sprint(args...))
+	t.Log(Failure + ": " + fmt.Sprint(args...))
 	t.Fail()
 }
 
 func (t *testHelper) Errorf(format string, args ...any) {
 	t.t.Helper()
-	t.Logf("ERROR: "+format, args...)
+	t.Logf(Failure+": "+format, args...)
 	t.Fail()
 }
 
@@ -129,20 +134,18 @@ func (t *testHelper) Cleanup(f func()) {
 	t.t.Cleanup(func() {
 		t.T().Helper()
 		start := time.Now()
-		t.Log("Performing cleanup")
+		t.T().Log()
+		t.T().Log("Performing cleanup")
 		f()
-		t.Logf("Cleanup completed in %.2fs", time.Now().Sub(start).Seconds())
+		t.T().Logf("Cleanup completed in %.2fs", time.Now().Sub(start).Seconds())
 	})
 }
 
 func (t *testHelper) LogStep(str string) {
 	t.t.Helper()
 	t.currentStep++
-	if t.currentStep > 1 {
-		t.Log("")
-	}
-	t.t.Logf("STEP %d: %s", t.currentStep, str)
 	t.Log("")
+	t.t.Logf("STEP %d: %s", t.currentStep, str)
 }
 
 func (t *testHelper) LogStepf(format string, args ...any) {
@@ -156,7 +159,7 @@ func (t *testHelper) CurrentStep() int {
 
 func (t *testHelper) LogSuccess(str string) {
 	t.t.Helper()
-	t.Logf("SUCCESS: " + str)
+	t.Log(Success + ": " + str)
 }
 
 func (t *testHelper) LogSuccessf(format string, args ...any) {
@@ -185,7 +188,7 @@ func (t *testHelper) WillRetry() bool {
 
 func (t *testHelper) indent() string {
 	if t.currentStep > 0 {
-		return "  "
+		return "   "
 	}
 	return ""
 }

--- a/pkg/util/test/test_helper_retry.go
+++ b/pkg/util/test/test_helper_retry.go
@@ -42,26 +42,24 @@ func (t *RetryTestHelper) Failed() bool {
 
 func (t *RetryTestHelper) Error(args ...any) {
 	t.t.Helper()
-	t.Log("transient error " + t.attemptString() + ": " + fmt.Sprint(args...))
+	t.Log(Failure + ": " + fmt.Sprint(args...))
 	t.Fail()
 }
 
 func (t *RetryTestHelper) Errorf(format string, args ...any) {
 	t.t.Helper()
-	t.Logf("transient error "+t.attemptString()+": "+format, args...)
-	t.Fail()
+	t.Error(fmt.Sprintf(format, args...))
 }
 
 func (t *RetryTestHelper) Fatal(args ...any) {
 	t.t.Helper()
-	t.Log("transient error " + t.attemptString() + ": " + fmt.Sprint(args...))
+	t.Error(args...)
 	t.FailNow()
 }
 
 func (t *RetryTestHelper) Fatalf(format string, args ...any) {
 	t.t.Helper()
-	t.Logf("transient error "+t.attemptString()+": "+format, args...)
-	t.FailNow()
+	t.Fatal(fmt.Sprintf(format, args...))
 }
 
 // func (t *RetryTestHelper) LogStep(str string) {


### PR DESCRIPTION
- don't log start of attempt (completion should suffice)
- don't insert empty lines between attempts
- insert empty line before "(Sub)test completed" statement
- don't insert empty line before or after STEP
- insert empty line before cleanup
- log failed assertions as "FAILURE" instead of "ERROR"
- log retriable failures as "FAILURE" instead of "transient error (will retry)" (it's evident from the "Attempt failed" lines that this failure is retriable
- increase indent within STEP -