### PR TITLE
Fix make check

### DIFF
--- a/scripts/compiletests.sh
+++ b/scripts/compiletests.sh
@@ -7,5 +7,5 @@ directories=$(find . -name "*_test.go" | xargs -n1 dirname | sort -u)
 for dir in $directories
 do
   echo "Compiling tests in $dir ..."
-  go test -c $dir
+  go test -c $dir -o /dev/null
 done


### PR DESCRIPTION
The make check command compiled the tests and polluted the working directory with *.test files. This change prevents those files from being created.