### PR TITLE
Remove unused env variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ RUN microdnf install --nodocs tar gcc gzip git bind-utils findutils sudo \
 
 ENV GOROOT=/go
 ENV GOPATH=/root/go
-ENV GODEBUG "x509ignoreCN=0"
 ENV PATH=$GOROOT/bin:$PATH
 
 ENV OCP_API_URL ${OCP_API_URL}
@@ -28,7 +27,6 @@ ENV SAMPLEARCH ${SAMPLEARCH}
 ENV NIGHTLY ${NIGHTLY}
 ENV ROSA ${ROSA}
 ENV MUSTGATHERTAG ${MUSTGATHERTAG}
-ENV IPV6 ${IPV6}
 
 COPY . /opt/maistra-test-tool
 WORKDIR /opt/maistra-test-tool

--- a/pkg/tests/ossm/setup.go
+++ b/pkg/tests/ossm/setup.go
@@ -46,7 +46,6 @@ var (
 
 	smcpName      = env.GetDefaultSMCPName()
 	meshNamespace = env.GetDefaultMeshNamespace()
-	ipv6          = env.Getenv("IPV6", "false")
 )
 
 func DefaultSMCP() SMCP {
@@ -74,9 +73,6 @@ func SetupEnvVars(t test.TestHelper) {
 func BasicSetup(t test.TestHelper) {
 	t.T().Helper()
 	SetupEnvVars(t)
-	if ipv6 == "true" {
-		t.Log("Running the test with IPv6 configuration")
-	}
 
 	if env.Getenv("NIGHTLY", "false") == "true" {
 		installNightlyOperators(t)

--- a/tests/test.env
+++ b/tests/test.env
@@ -1,9 +1,7 @@
 export MESHNAMESPACE=istio-system
 export SMCPNAME=basic
-export GODEBUG="x509ignoreCN=0"
 export SAMPLEARCH=x86
 export ROSA=false
 export TEST_GROUP=full
 export MUSTGATHERTAG=2.3
 export SMCPVERSION=2.3
-export IPV6=false


### PR DESCRIPTION
IPV6 is not used and GODEBUG is no longer needed. It was fixed by https://github.com/maistra/maistra-test-tool/pull/341