### PR TITLE
Update TestExternalCertificate to use x509

### DIFF
--- a/pkg/tests/tasks/security/certificate/external_ca_test.go
+++ b/pkg/tests/tasks/security/certificate/external_ca_test.go
@@ -15,19 +15,19 @@
 package certificate
 
 import (
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"os"
 	"testing"
 
 	"github.com/maistra/maistra-test-tool/pkg/app"
-	"github.com/maistra/maistra-test-tool/pkg/util"
 	"github.com/maistra/maistra-test-tool/pkg/util/check/assert"
 	"github.com/maistra/maistra-test-tool/pkg/util/curl"
 	"github.com/maistra/maistra-test-tool/pkg/util/env"
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
 	"github.com/maistra/maistra-test-tool/pkg/util/pod"
 	"github.com/maistra/maistra-test-tool/pkg/util/retry"
-	"github.com/maistra/maistra-test-tool/pkg/util/shell"
 	"github.com/maistra/maistra-test-tool/pkg/util/test"
 )
 
@@ -35,89 +35,152 @@ func TestExternalCertificate(t *testing.T) {
 	test.NewTest(t).Id("T17").Groups(test.Full, test.ARM, test.InterOp).Run(func(t test.TestHelper) {
 		const ns = "bookinfo"
 
-		var tmpDir = ""
-
 		t.Cleanup(func() {
-			if tmpDir != "" {
-				os.RemoveAll(tmpDir)
-			}
-
+			t.Logf("Recreate namespace %s", ns)
 			oc.RecreateNamespace(t, ns, meshNamespace)
 		})
 
 		t.LogStep("Uninstall existing SMCP")
 		oc.RecreateNamespace(t, meshNamespace)
 
-		t.LogStep("Create cacerts Secret")
+		t.LogStep("Create cacerts secret")
 		oc.CreateGenericSecretFromFiles(t, meshNamespace, "cacerts",
 			"ca-cert.pem="+sampleCACert,
 			"ca-key.pem="+sampleCAKey,
 			"root-cert.pem="+sampleCARoot,
 			"cert-chain.pem="+sampleCAChain)
+		rootCert := readPemCertificatesFromFile(t, sampleCARoot)[0]
+		chainCerts := readPemCertificatesFromFile(t, sampleCAChain)
 
-		t.LogStep("Apply SMCP to configure certificate authority to use cacerts Secret")
+		t.LogStep("Apply SMCP to configure certificate authority to use cacerts secret")
 		oc.ApplyString(t, meshNamespace, createSMCPWithCustomCert(smcpName, ns))
 		oc.WaitSMCPReady(t, meshNamespace, smcpName)
 
 		t.LogStep("Install bookinfo")
 		app.InstallAndWaitReady(t, app.BookinfoWithMTLS(ns))
 
-		t.LogStep("Checking response from productpage.")
+		t.LogStep("Wait for response from productpage app")
 		retry.UntilSuccess(t, func(t test.TestHelper) {
 			curl.Request(t,
 				app.BookinfoProductPageURL(t, meshNamespace), nil,
 				assert.ResponseStatus(200))
 		})
 
-		if env.GetArch() == "p" || env.GetArch() == "z" {
-			t.Log("NOTE: Not checking certificates, because test is running in P or Z environment")
-			return
-		}
+		t.LogStep("Retrieve certificates from bookinfo details service")
 
-		t.LogStep("Retrieve certificates using the 'openssl s_client -showcerts' command")
-		tmpDir = shell.CreateTempDir(t, "cacerts")
-		oc.Exec(t, pod.MatchingSelector("app=productpage", ns), "istio-proxy",
-			fmt.Sprintf(`openssl s_client -showcerts -connect details:9080 > '%s/bookinfo-proxy-cert.txt' || true`, tmpDir))
-
-		t.LogStep("Extract certificates")
-		shell.Executef(t,
-			`sed -n '/-----BEGIN CERTIFICATE-----/{:start /-----END CERTIFICATE-----/!{N;b start};/.*/p}' '%s/bookinfo-proxy-cert.txt' > '%s/certs.pem'`,
-			tmpDir, tmpDir)
-		shell.Executef(t,
-			`awk 'BEGIN {counter=0;} /BEGIN CERT/{counter++} { print > "%s/proxy-cert-" counter ".pem"}' < '%s/certs.pem'`,
-			tmpDir, tmpDir)
-
-		t.NewSubTest("root certificate").Run(func(t test.TestHelper) {
-			shell.Executef(t, `openssl x509 -in '%s' -text -noout > '%s/root-cert.crt.txt'`, sampleCARoot, tmpDir)
-			shell.Executef(t, `openssl x509 -in '%s/proxy-cert-3.pem' -text -noout > '%s/pod-root-cert.crt.txt'`, tmpDir, tmpDir)
-
-			if err := util.CompareFiles(fmt.Sprintf("%s/root-cert.crt.txt", tmpDir), fmt.Sprintf("%s/pod-root-cert.crt.txt", tmpDir)); err != nil {
-				t.Errorf("Root certs do not match: %v", err)
-			} else {
-				t.LogSuccess("Root certificate received from pod matches the root certificate in cacerts")
-			}
+		var returnedCerts []*x509.Certificate
+		retry.UntilSuccess(t, func(t test.TestHelper) {
+			opensslOutput := oc.Exec(t,
+				pod.MatchingSelector("app=productpage", ns), "istio-proxy",
+				`openssl s_client -showcerts -connect details:9080 || true`) // the "|| true" is needed until oc.Exec can ignore return codes
+			returnedCerts = readPemCertificatesFromText(t, opensslOutput)
 		})
+		certToVerify := returnedCerts[0]
+		otherCerts := returnedCerts[1:]
 
-		t.NewSubTest("CA certificate").Run(func(t test.TestHelper) {
-			shell.Executef(t, `openssl x509 -in '%s' -text -noout > '%s/ca-cert.crt.txt'`, sampleCACert, tmpDir)
-			shell.Executef(t, `openssl x509 -in '%s/proxy-cert-2.pem' -text -noout > '%s/pod-cert-chain-ca.crt.txt'`, tmpDir, tmpDir)
+		verifyContainsCerts(t, otherCerts, chainCerts,
+			"The cert-chain certificates are present in the certificates sent by the tested service",
+			"The cert-chain certificates were not found in the certificates sent by the tested service")
 
-			if err := util.CompareFiles(fmt.Sprintf("%s/ca-cert.crt.txt", tmpDir), fmt.Sprintf("%s/pod-cert-chain-ca.crt.txt", tmpDir)); err != nil {
-				t.Errorf("CA certs do not match: %v", err)
-			} else {
-				t.LogSuccess("CA certificate received from pod matches the CA certificate in cacerts")
-			}
-		})
-
-		t.NewSubTest("certificate chain").Run(func(t test.TestHelper) {
-			shell.Executef(t, `cat '%s' '%s' > '%s/sample-cert-and-root-cert.pem'`, sampleCACert, sampleCARoot, tmpDir)
-			shell.Execute(t,
-				fmt.Sprintf(`openssl verify -CAfile '%s/sample-cert-and-root-cert.pem' '%s/proxy-cert-1.pem'`, tmpDir, tmpDir),
-				assert.OutputContains(fmt.Sprintf("%s/proxy-cert-1.pem: OK", tmpDir),
-					"Certificate chain verified.",
-					"Certificate chain could not be verified."))
-		})
+		verifyCertificate(t, certToVerify, []*x509.Certificate{rootCert}, otherCerts,
+			"Certificate trust chain successfully verified",
+			"Unable to verify certificate trust chain")
 	})
+}
+
+func verifyContainsCerts(t test.TestHelper, actualCerts, expectedCerts []*x509.Certificate, successMsg, failureMsg string) {
+	t.T().Helper()
+
+	// Make a copy of expectedCerts because we will clobber it
+	certsToFind := make([]*x509.Certificate, len(expectedCerts), len(expectedCerts))
+	copy(certsToFind, expectedCerts)
+
+	for _, certA := range actualCerts {
+		for idxB, certB := range certsToFind {
+			if certA.Equal(certB) {
+				if len(certsToFind) == 1 {
+					t.LogSuccess(successMsg)
+					return
+				}
+				// "Remove" certB from certsToFind
+				certsToFind[idxB] = certsToFind[len(certsToFind)-1] // overwrite certB with last element
+				certsToFind[len(certsToFind)-1] = nil               // remove stale ref to last element
+				certsToFind = certsToFind[:len(certsToFind)-1]      // resize slice
+				break
+			}
+		}
+	}
+	t.Error(failureMsg)
+}
+
+func verifyCertificate(t test.TestHelper, cert *x509.Certificate, rootCerts, intermediateCerts []*x509.Certificate, successMsg, failureMsg string) {
+	t.T().Helper()
+	rootCertPool := x509.NewCertPool()
+	for _, c := range rootCerts {
+		rootCertPool.AddCert(c)
+	}
+
+	intermediateCertPool := x509.NewCertPool()
+	for _, c := range intermediateCerts {
+		intermediateCertPool.AddCert(c)
+	}
+
+	chains, err := cert.Verify(x509.VerifyOptions{
+		Roots:         rootCertPool,
+		Intermediates: intermediateCertPool})
+
+	if err != nil {
+		// x509.UnknownAuthorityError will be generated during a non-exceptional failure and can be ignored here
+		_, isUnkAuthErr := err.(x509.UnknownAuthorityError)
+		if !isUnkAuthErr {
+			t.Fatalf(`Error while verifying certificate: %v`, err)
+		}
+	}
+
+	if len(chains) > 0 {
+		t.LogSuccess(successMsg)
+	} else {
+		t.Error(failureMsg)
+	}
+}
+
+func readPemCertificatesFromFile(t test.TestHelper, path string) []*x509.Certificate {
+	t.T().Helper()
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf(`Error reading certificates: Unable to open "%s" for reading: %v`, path, err)
+	}
+	return readPemCertificates(t, bytes)
+}
+
+func readPemCertificatesFromText(t test.TestHelper, text string) []*x509.Certificate {
+	t.T().Helper()
+
+	return readPemCertificates(t, []byte(text))
+}
+
+func readPemCertificates(t test.TestHelper, pemData []byte) []*x509.Certificate {
+	t.T().Helper()
+	var certificates []*x509.Certificate
+	for {
+		block, rest := pem.Decode(pemData)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			t.Fatalf("failed to parse certificate: %w", err)
+		}
+		certificates = append(certificates, cert)
+		pemData = rest
+	}
+	if len(certificates) == 0 {
+		t.Fatal("Failed to read certificates: No certificates found in text.")
+	}
+	return certificates
 }
 
 func createSMCPWithCustomCert(smcpName, memberNs string) string {


### PR DESCRIPTION
Updates TestExternalCertificate to use methods from `crypo/x509` over calls to `openssl` and file comparison. I also took the time to really understand what the test was trying to accomplish and re-wrote the test to eliminate unnecessary steps.

The test now only verifies:

1. That the certificates stored in the admin-provided `cert-chain.pem` are included in the returned certificates.
    - `cert-chain.pem` contains a chain of certificates beginning with (and including) the certificate from `ca-cert.pem` and ending just before (but not including) the certificate from `root-cert.pem`. Therefore, it is redundant to check for the certificate from `ca-cert.pem` in the returned certificates.
    - The certificate from `root-cert.pem` _may_ be returned by the endpoint, but it serves no purpose as the client must already both have and trust it. Therefore, there is no need to verify that the certificate from `root-cert.pem` is returned by the endpoint.
2. That the endpoint certificate has a valid chain of trust back to the root certificate.
    - This is in case, in the future, istio itself or it's certificate authority (e.g. Citadel or some other replacement like cert-manager) were to add additional intermediates of its own between the cluster CA (from `ca-cert.pem`) and the certificate issued to the endpoint.

I added some helper functions in `external_ca_test.go` that may be useful elsewhere in the future:

1. `verifyContainsCerts`
    - Verifies the certificates in `certs` are contained in `certCollection`. This does not currently handle duplicates present in `certs` but I don't anticipate it would need to.
2. `verifyCertificate`
    - verifies that `cert` can be trust chained to at least one certificate of `rootCerts` through the certificates of `intermediateCerts`.
3. `readPemCertificates`
    - reads and parses all PEM formatted certificates found by scanning through `reader`.
    - `readPemCertificatesFromText` and `readPemCertificatesFromFile` are convenience wrappers that first create an `io.Reader` from a string or file path, respectively.