### PR TITLE
OSSM-3840 Use `oc replace` when setting up SMCP

### DIFF
--- a/pkg/tests/ossm/setup.go
+++ b/pkg/tests/ossm/setup.go
@@ -94,7 +94,7 @@ func InstallSMCPVersion(t test.TestHelper, ns string, ver version.Version) {
 }
 
 func InstallSMCPCustom(t test.TestHelper, ns string, smcp SMCP) {
-	oc.ApplyString(t, ns, getSMCPManifestCustom(t, smcp))
+	oc.ReplaceOrApplyString(t, ns, getSMCPManifestCustom(t, smcp))
 }
 
 func DeleteSMCPVersion(t test.TestHelper, ns string, ver version.Version) {

--- a/pkg/util/oc/oc.go
+++ b/pkg/util/oc/oc.go
@@ -16,9 +16,19 @@ func ApplyString(t test.TestHelper, ns string, yamls ...string) {
 	DefaultOC.ApplyString(t, ns, yamls...)
 }
 
+func ReplaceOrApplyString(t test.TestHelper, ns string, yaml string) {
+	t.T().Helper()
+	DefaultOC.ReplaceOrApplyString(t, ns, yaml)
+}
+
 func ApplyTemplate(t test.TestHelper, ns string, template string, input interface{}) {
 	t.T().Helper()
 	DefaultOC.ApplyTemplateString(t, ns, template, input)
+}
+
+func ReplaceOrApplyTemplate(t test.TestHelper, ns string, template string, input interface{}) {
+	t.T().Helper()
+	DefaultOC.ReplaceOrApplyTemplate(t, ns, template, input)
 }
 
 func DeleteFromTemplate(t test.TestHelper, ns string, yaml string, data interface{}) {

--- a/pkg/util/oc/pod_commands.go
+++ b/pkg/util/oc/pod_commands.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/maistra/maistra-test-tool/pkg/util/check/assert"
 	"github.com/maistra/maistra-test-tool/pkg/util/check/common"
+	"github.com/maistra/maistra-test-tool/pkg/util/check/require"
 	"github.com/maistra/maistra-test-tool/pkg/util/retry"
 	"github.com/maistra/maistra-test-tool/pkg/util/shell"
 	"github.com/maistra/maistra-test-tool/pkg/util/test"
@@ -84,6 +85,7 @@ func (o OC) WaitPodReady(t test.TestHelper, podLocator PodLocatorFunc) {
 	t.T().Helper()
 	var pod NamespacedName
 	retry.UntilSuccess(t, func(t test.TestHelper) {
+		t.T().Helper()
 		pod = podLocator(t, &o)
 		condition := o.Invokef(t, "kubectl -n %s wait --for condition=Ready pod %s --timeout 1s || true", pod.Namespace, pod.Name) // TODO: Change shell execute to do not fail on error
 		if strings.Contains(condition, "condition met") {
@@ -145,9 +147,10 @@ func (o OC) DeletePodNoWait(t test.TestHelper, podLocator PodLocatorFunc) {
 func (o OC) WaitCondition(t test.TestHelper, ns string, kind string, name string, condition string) {
 	t.T().Helper()
 	retry.UntilSuccessWithOptions(t, retry.Options().MaxAttempts(30), func(t test.TestHelper) {
+		t.T().Helper()
 		shell.Execute(t,
 			fmt.Sprintf(`oc wait -n %s %s/%s --for condition=%s  --timeout %s`, ns, kind, name, condition, "10s"),
-			assert.OutputContains(condition,
+			require.OutputContains("condition met",
 				fmt.Sprintf("Condition %s met by %s %s/%s", condition, kind, ns, name),
 				fmt.Sprintf("Condition %s not met by %s %s/%s, retrying", condition, kind, ns, name)))
 	})


### PR DESCRIPTION
This ensures that the resulting SMCP spec exactly matches what each test needs. Previously, we used `oc apply`, which doesn't remove spec fields that were added by the previous test(s).