### PR TITLE
Improve oc.WaitCondition

### DIFF
--- a/pkg/util/oc/oc_struct.go
+++ b/pkg/util/oc/oc_struct.go
@@ -212,7 +212,6 @@ func (o OC) WaitSMCPReady(t test.TestHelper, ns string, name string) {
 	t.T().Helper()
 	o.withKubeconfig(t, func() {
 		t.T().Helper()
-		t.Logf("Wait for SMCP %s/%s to be ready", ns, name)
 		o.WaitCondition(t, ns, "smcp", name, "Ready")
 	})
 }

--- a/pkg/util/retry/retry.go
+++ b/pkg/util/retry/retry.go
@@ -23,9 +23,7 @@ func UntilSuccessWithOptions(t test.TestHelper, options RetryOptions, f func(t t
 			attemptHelper = t
 			f(attemptHelper)
 		} else {
-			retryTestHelper := test.NewRetryTestHelper(t.T(), t.CurrentStep(), i, options.maxAttempts)
-			attemptHelper = retryTestHelper
-			retryTestHelper.Attempt(f)
+			attemptHelper = attemptInternal(t, f, i, options.maxAttempts)
 		}
 
 		if attemptHelper.Failed() {
@@ -67,4 +65,20 @@ func UntilSuccessWithOptions(t test.TestHelper, options RetryOptions, f func(t t
 			break
 		}
 	}
+}
+
+// Attempt runs the given function, captures any errors thrown by the function, and
+// returns a RetryTestHelper, which you can use to:
+// - check if the attempt failed by invoking retryTestHelper.Failed()
+// - print everything that the function logged by invoking retryTestHelper.FlushLogBuffer()
+func Attempt(t test.TestHelper, f func(t test.TestHelper)) *test.RetryTestHelper {
+	t.T().Helper()
+	return attemptInternal(t, f, 0, 1)
+}
+
+func attemptInternal(t test.TestHelper, f func(t test.TestHelper), currentAttempt, maxAttempts int) *test.RetryTestHelper {
+	t.T().Helper()
+	retryTestHelper := test.NewRetryTestHelper(t.T(), t.CurrentStep(), currentAttempt, maxAttempts)
+	retryTestHelper.Attempt(f)
+	return retryTestHelper
 }


### PR DESCRIPTION
- make failures easier to debug by logging the output of `oc describe` after the `oc wait` command fails
- log "Wait for condition..." instead of low-level `shell.Execute` failures