### PR TITLE
Fix TestCertManager

### DIFF
--- a/pkg/util/check/assert/common.go
+++ b/pkg/util/check/assert/common.go
@@ -9,6 +9,6 @@ func assertFailure(t test.TestHelper, msg string, detailMsg string) {
 	if detailMsg == "" {
 		t.Error(msg)
 	} else {
-		t.Errorf("%s (%s)", msg, detailMsg)
+		t.Errorf("%s; %s", msg, detailMsg)
 	}
 }

--- a/pkg/util/check/assert/output.go
+++ b/pkg/util/check/assert/output.go
@@ -8,7 +8,14 @@ import (
 func OutputContains(str string, successMsg, failureMsg string) common.CheckFunc {
 	return func(t test.TestHelper, input string) {
 		t.T().Helper()
-		common.CheckOutputContains(t, input, str, successMsg, failureMsg, assertFailure)
+		common.CheckOutputContainsAny(t, input, []string{str}, successMsg, failureMsg, assertFailure)
+	}
+}
+
+func OutputContainsAny(str []string, successMsg, failureMsg string) common.CheckFunc {
+	return func(t test.TestHelper, input string) {
+		t.T().Helper()
+		common.CheckOutputContainsAny(t, input, str, successMsg, failureMsg, assertFailure)
 	}
 }
 

--- a/pkg/util/check/common/output.go
+++ b/pkg/util/check/common/output.go
@@ -9,20 +9,29 @@ import (
 
 type CheckFunc func(t test.TestHelper, input string)
 
-func CheckOutputContains(t test.TestHelper, output, str, successMsg, failureMsg string, failure FailureFunc) {
+func CheckOutputContainsAny(t test.TestHelper, output string, expected []string, successMsg, failureMsg string, failure FailureFunc) {
 	t.T().Helper()
-	if strings.Contains(output, str) {
-		if successMsg == "" {
-			successMsg = fmt.Sprintf("string '%s' found in output", str)
+	for _, str := range expected {
+		if strings.Contains(output, str) {
+			if successMsg == "" {
+				successMsg = fmt.Sprintf("string '%s' found in output", expected)
+			}
+			logSuccess(t, successMsg)
+			return
 		}
-		logSuccess(t, successMsg)
-	} else {
-		detailMsg := fmt.Sprintf("expected to find the string '%s' in the output, but it wasn't found", str)
-		if !t.WillRetry() {
-			detailMsg += "\nfull output:\n" + output
-		}
-		failure(t, failureMsg, detailMsg)
 	}
+	// none of the expected strings were found
+	var detailMsg string
+	if len(expected) == 1 {
+		detailMsg = fmt.Sprintf("expected to find the string '%s' in the output, but it wasn't found", expected[0])
+	} else {
+		detailMsg = fmt.Sprintf("expected to find any of '%v' in the output, but none wasn't found", expected)
+	}
+	if !t.WillRetry() {
+		detailMsg += "; full output:\n" + output
+	}
+	failure(t, failureMsg, detailMsg)
+
 }
 
 func CheckOutputDoesNotContain(t test.TestHelper, output, str, successMsg, failureMsg string, failure FailureFunc) {
@@ -30,7 +39,7 @@ func CheckOutputDoesNotContain(t test.TestHelper, output, str, successMsg, failu
 	if strings.Contains(output, str) {
 		detailMsg := fmt.Sprintf("expected the string '%s' to be absent from the command output, but it was present", str)
 		if !t.WillRetry() {
-			detailMsg += "\nfull output:\n" + output
+			detailMsg += "; full output:\n" + output
 		}
 		failure(t, failureMsg, detailMsg)
 	} else {

--- a/pkg/util/check/require/common.go
+++ b/pkg/util/check/require/common.go
@@ -9,6 +9,6 @@ func requireFailure(t test.TestHelper, msg string, detailMsg string) {
 	if detailMsg == "" {
 		t.Fatalf(msg)
 	} else {
-		t.Fatalf("%s (%s)", msg, detailMsg)
+		t.Fatalf("%s; %s", msg, detailMsg)
 	}
 }

--- a/pkg/util/check/require/output.go
+++ b/pkg/util/check/require/output.go
@@ -8,7 +8,14 @@ import (
 func OutputContains(str string, successMsg, failureMsg string) common.CheckFunc {
 	return func(t test.TestHelper, input string) {
 		t.T().Helper()
-		common.CheckOutputContains(t, input, str, successMsg, failureMsg, requireFailure)
+		common.CheckOutputContainsAny(t, input, []string{str}, successMsg, failureMsg, requireFailure)
+	}
+}
+
+func OutputContainsAny(str []string, successMsg, failureMsg string) common.CheckFunc {
+	return func(t test.TestHelper, input string) {
+		t.T().Helper()
+		common.CheckOutputContainsAny(t, input, str, successMsg, failureMsg, requireFailure)
 	}
 }
 


### PR DESCRIPTION
If the foo namespace exists and already contains the `istio-ca-root-cert`, the cert-manager-istio-csr logs contain `updating ConfigMap data` instead of `creating configmap with root CA data`