### PR TITLE
Improve runtests

### DIFF
--- a/pkg/util/env/env.go
+++ b/pkg/util/env/env.go
@@ -82,5 +82,5 @@ func IsLogFailedRetryAttempts() bool {
 }
 
 func GetOutputDir() string {
-	return getenv("OUTPUT_DIR", fmt.Sprintf("%s/tests/result-%s", GetRootDir(), initTime.Format("20060102150405")))
+	return getenv("OUTPUT_DIR", fmt.Sprintf("%s/tests/result-%s/%s", GetRootDir(), initTime.Format("20060102150405"), GetSMCPVersion()))
 }

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -14,58 +14,61 @@ logHeader() {
     log
 }
 
-require_SMCP_VERSION() {
+runTestsAgainstVersion() {
     if [ -z "$SMCP_VERSION" ]; then
         echo "ERROR: must specify version in SMCP_VERSION env var"
         exit 1
     fi
-}
 
-runAllTests() {
-    require_SMCP_VERSION
-
-    local dir="$1"
+    echo "Output dir: $OUTPUT_DIR"
+    mkdir -p "$OUTPUT_DIR"
 
     echo > "$LOG_FILE"
-    if [ -n "$TEST_GROUP" ]; then
-        logHeader "Executing tests in group '$TEST_GROUP' against SMCP $SMCP_VERSION"
+
+    if [ -z "$TEST_CASE" ]; then
+        if [ -n "$TEST_GROUP" ]; then
+            logHeader "Executing tests in group '$TEST_GROUP' against SMCP $SMCP_VERSION"
+        else
+            logHeader "Executing all tests against SMCP $SMCP_VERSION"
+        fi
+
+        gotestsum -f standard-verbose --packages "$TEST_DIR" \
+        --max-fails 10 \
+        --rerun-fails=5 --rerun-fails-max-failures 10 --rerun-fails-run-root-test --rerun-fails-report "$RERUNS_FILE" \
+        --junitfile "$REPORT_FILE" --junitfile-project-name "maistra-test-tool-$SMCP_VERSION" --junitfile-hide-empty-pkg \
+        --junitfile-testsuite-name relative --junitfile-testcase-classname relative \
+        -- -timeout 1h -count 1 -p 1 2>&1 \
+        | tee -a "$LOG_FILE"
     else
-        logHeader "Executing all tests against SMCP $SMCP_VERSION"
+        logHeader "Executing $testName against SMCP $SMCP_VERSION"
+
+        gotestsum -f standard-verbose --packages "$TEST_DIR" \
+        --rerun-fails=5 --rerun-fails-run-root-test --rerun-fails-report "$RERUNS_FILE" \
+        --junitfile "$REPORT_FILE" --junitfile-project-name "maistra-test-tool-$SMCP_VERSION" --junitfile-hide-empty-pkg \
+        --junitfile-testsuite-name relative --junitfile-testcase-classname relative \
+        -- -timeout 30m -count 1 -p 1 -run "^$testName$" 2>&1 \
+        | tee -a "$LOG_FILE"
     fi
 
-    gotestsum -f standard-verbose --packages "$dir/..." \
-    --max-fails 10 \
-    --rerun-fails=5 --rerun-fails-max-failures 10 --rerun-fails-run-root-test --rerun-fails-report "$RERUNS_FILE" \
-    --junitfile "$REPORT_FILE" --junitfile-project-name "maistra-test-tool-$SMCP_VERSION" --junitfile-hide-empty-pkg \
-    --junitfile-testsuite-name relative --junitfile-testcase-classname relative \
-    -- -timeout 1h -count 1 -p 1 2>&1 \
-    | tee -a "$LOG_FILE"
-}
+    # extract skipped tests into skipped.log
+    sed -n '/=== Skipped/,/=== Failed\|DONE/{/=== Failed\|DONE/!p}' "$LOG_FILE" > "$OUTPUT_DIR/skipped.log"
 
-runTest() {
-    require_SMCP_VERSION
-
-    local dir="$1"
-    local testName="$2"
-
-    echo > "$LOG_FILE"
-    logHeader "Executing $testName against SMCP $SMCP_VERSION"
-
-    gotestsum -f standard-verbose --packages "$dir/" \
-    --rerun-fails=5 --rerun-fails-run-root-test --rerun-fails-report "$RERUNS_FILE" \
-    --junitfile "$REPORT_FILE" --junitfile-project-name "maistra-test-tool-$SMCP_VERSION" --junitfile-hide-empty-pkg \
-    --junitfile-testsuite-name relative --junitfile-testcase-classname relative \
-    -- -timeout 30m -count 1 -p 1 -run "^$testName$" 2>&1 \
-    | tee -a "$LOG_FILE"
+    # extract failed tests into failed.log
+    sed -n '/=== Failed/,/DONE/{/DONE/!p}' "$LOG_FILE" > "$OUTPUT_DIR/failed.log"
 }
 
 resetCluster() {
     echo
     echo "Resetting cluster by deleting namespaces used in the test suite"
     oc delete namespace istio-system bookinfo foo bar legacy mesh-external cert-manager --ignore-not-found
+    echo
 }
 
 main() {
+    if [ -n "$1" ]; then
+        export TEST_CASE="$1"
+    fi
+
     if [ -z "$SMCP_VERSION" ]; then
         echo
         echo "Executing tests against all supported versions: ${SUPPORTED_VERSIONS[*]}"
@@ -73,9 +76,6 @@ main() {
     else
         echo "Executing tests against SMCP version $SMCP_VERSION"
     fi
-    export OUTPUT_DIR="$PWD/tests/result-$(date +%Y%m%d%H%M%S)"
-    echo "Output dir: $OUTPUT_DIR"
-    mkdir -p "$OUTPUT_DIR"
 
     if [ -n "${OCP_CRED_PSW}" ]; then
         oc login -u ${OCP_CRED_USR} -p ${OCP_CRED_PSW} --server=${OCP_API_URL} --insecure-skip-tls-verify=true
@@ -83,15 +83,15 @@ main() {
         oc login --token=${OCP_TOKEN} --server=${OCP_API_URL} --insecure-skip-tls-verify=true
     fi
 
-    testName="${TEST_CASE:-$1}"
-    if [ -n "$testName" ]; then
+    export TEST_DIR=""
+    if [ -n "$TEST_CASE" ]; then
         # find the directory containing the specified test
-        dir=""
+        TEST_DIR=""
         file=""
         for f in $(find . -type f -name "*_test.go"); do
-            if grep -q "func $testName(" "$f"; then
-                if [ -z "$dir" ]; then
-                    dir=$(dirname "$f")
+            if grep -q "func $TEST_CASE(" "$f"; then
+                if [ -z "$TEST_DIR" ]; then
+                    TEST_DIR=$(dirname "$f")
                     file="$f"
                 else
                     echo >&2 "ERROR: Multiple tests with the given name were found. Please ensure test names are unique!"
@@ -100,11 +100,14 @@ main() {
             fi
         done
 
-        if [ -z "$dir" ]; then
-            echo >&2 "ERROR: Could not find test $testName"
+        if [ -z "$TEST_DIR" ]; then
+            echo >&2 "ERROR: Could not find test $TEST_CASE"
             exit 1
         fi
-        echo "Found $testName in file $file."
+        TEST_DIR="$TEST_DIR/"
+        echo "Found $TEST_CASE in file $file."
+    else
+        TEST_DIR="$PWD/pkg/tests/..."
     fi
 
     resetCluster
@@ -116,36 +119,30 @@ main() {
     if [ -z "$SMCP_VERSION" ]; then
         for ver in ${SUPPORTED_VERSIONS[@]}; do
             export SMCP_VERSION="$ver"
-            export LOG_FILE="$OUTPUT_DIR/output_${SMCP_VERSION}.log"
-            export REPORT_FILE="$OUTPUT_DIR/report_${SMCP_VERSION}.xml"
-            export RERUNS_FILE="$OUTPUT_DIR/reruns_${SMCP_VERSION}.txt"
+            export OUTPUT_DIR="${OUTPUT_DIR_BASE}/${SMCP_VERSION}"  # also used in env.GetOutputDir(), so must be exported
+            export LOG_FILE="$OUTPUT_DIR/output.log"
+            export REPORT_FILE="$OUTPUT_DIR/report.xml"
+            export RERUNS_FILE="$OUTPUT_DIR/reruns.txt"
 
             versions+=("$SMCP_VERSION")
             logFiles["$SMCP_VERSION"]="$LOG_FILE"
             reportFiles["$SMCP_VERSION"]="$REPORT_FILE"
 
-            if [ -z "$testName" ]; then
-                runAllTests "$PWD/pkg/tests"
-            else
-                runTest "$dir" "$testName"
-            fi
+            runTestsAgainstVersion
             resetCluster
         done
     else
         SMCP_VERSION="v${SMCP_VERSION#v}" # prepend "v" if necessary
-        export LOG_FILE="$OUTPUT_DIR/output_${SMCP_VERSION}.log"
-        export REPORT_FILE="$OUTPUT_DIR/report_${SMCP_VERSION}.xml"
-        export RERUNS_FILE="$OUTPUT_DIR/reruns_${SMCP_VERSION}.txt"
+        export OUTPUT_DIR="${OUTPUT_DIR_BASE}/${SMCP_VERSION}"  # also used in env.GetOutputDir(), so must be exported
+        export LOG_FILE="$OUTPUT_DIR/output.log"
+        export REPORT_FILE="$OUTPUT_DIR/report.xml"
+        export RERUNS_FILE="$OUTPUT_DIR/reruns.txt"
 
         versions+=("$SMCP_VERSION")
         logFiles["$SMCP_VERSION"]="$LOG_FILE"
         reportFiles["$SMCP_VERSION"]="$REPORT_FILE"
 
-        if [ -z "$testName" ]; then
-            runAllTests "$PWD/pkg/tests"
-        else
-            runTest "$dir" "$testName"
-        fi
+        runTestsAgainstVersion
     fi
 
     echo
@@ -157,8 +154,18 @@ main() {
     echo
     echo "====== Test summary"
     for ver in "${versions[@]}"; do
-        echo "${ver}: $(tail -1 ${logFiles[$ver]})"
+        tail -10 ${logFiles[$ver]} | tac | sed -n -e "0,/DONE/{s/^/${ver}: /p}" | tac
     done
 }
 
-time main $@
+timedMain() {
+    time main $@
+}
+
+
+export OUTPUT_DIR_BASE="$PWD/tests/result-$(date +%Y%m%d%H%M%S)"
+echo "Output dir: $OUTPUT_DIR_BASE"
+mkdir -p "$OUTPUT_DIR_BASE"
+ln -sfn "$OUTPUT_DIR_BASE" "$PWD/tests/result-latest"
+
+timedMain $@ 2>&1 | tee "${OUTPUT_DIR_BASE}/output.log"


### PR DESCRIPTION
- split results dir into separate, per-version dirs
- store entire log output to output.log
- store logs of failed test to failed.log
- store skipped tests to skipped.log
- include "DONE" and the next line (such as "ERROR ending test run because max failures was reached") in test summary