### PR TITLE
Ensure the cert-manager namespace is cleaned up in TestCertManager

### DIFF
--- a/pkg/tests/tasks/security/certificate/cert_manager_test.go
+++ b/pkg/tests/tasks/security/certificate/cert_manager_test.go
@@ -36,8 +36,8 @@ func TestCertManager(t *testing.T) {
 			oc.DeleteFromString(t, certManagerOperatorNs, certManagerOperator)
 			oc.DeleteSecret(t, meshNamespace, "istiod-tls")
 			oc.DeleteSecret(t, meshNamespace, "istio-ca")
-			oc.DeleteNamespace(t, certManagerNs)
 			oc.DeleteNamespace(t, certManagerOperatorNs)
+			oc.DeleteNamespace(t, certManagerNs)
 			oc.RecreateNamespace(t, ns.Foo)
 		})
 


### PR DESCRIPTION
Although the test previously did delete the namespace, the cert-manager operator apparently recreated it. So, we must first terminate the operator and then delete the namespace.