### PR TITLE
OSSM-3807: removing Jenkinsfile as new version is now used

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,0 @@
-@Library('servicemesh-lib') _
-
-maistraTestTool(
-    maistraVersion: '2.3'
-)


### PR DESCRIPTION
Jenkinsfile is now located in https://gitlab.cee.redhat.com/istio/servicemesh-qe/jenkins-csb-declaration