### PR TITLE
Fix TestTrustDomainMigration

### DIFF
--- a/pkg/tests/tasks/security/authorization/trust_domain_test.go
+++ b/pkg/tests/tasks/security/authorization/trust_domain_test.go
@@ -23,10 +23,12 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/app"
 	"github.com/maistra/maistra-test-tool/pkg/tests/ossm"
 	"github.com/maistra/maistra-test-tool/pkg/util/check/assert"
+	"github.com/maistra/maistra-test-tool/pkg/util/env"
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
 	"github.com/maistra/maistra-test-tool/pkg/util/pod"
 	"github.com/maistra/maistra-test-tool/pkg/util/retry"
 	. "github.com/maistra/maistra-test-tool/pkg/util/test"
+	"github.com/maistra/maistra-test-tool/pkg/util/version"
 )
 
 func TestTrustDomainMigration(t *testing.T) {
@@ -108,6 +110,10 @@ spec:
 `, mtls, domain, alias))
 
 	oc.WaitSMCPReady(t, meshNamespace, smcpName)
+	if env.GetSMCPVersion().LessThan(version.SMCP_2_2) {
+		t.Log("Restarting deployments")
+		oc.RestartAllPods(t, meshNamespace)
+	}
 }
 
 const TrustDomainPolicy = `

--- a/pkg/tests/tasks/security/authorization/trust_domain_test.go
+++ b/pkg/tests/tasks/security/authorization/trust_domain_test.go
@@ -113,7 +113,7 @@ spec:
 	if env.GetSMCPVersion().LessThan(version.SMCP_2_2) {
 		t.Log("Restarting deployments")
 		oc.RestartAllPods(t, meshNamespace)
-		oc.WaitSMCPReady(t, meshNamespace, smcpName)
+		oc.WaitAllPodsReady(t, meshNamespace)
 	}
 }
 

--- a/pkg/tests/tasks/security/authorization/trust_domain_test.go
+++ b/pkg/tests/tasks/security/authorization/trust_domain_test.go
@@ -113,6 +113,7 @@ spec:
 	if env.GetSMCPVersion().LessThan(version.SMCP_2_2) {
 		t.Log("Restarting deployments")
 		oc.RestartAllPods(t, meshNamespace)
+		oc.WaitSMCPReady(t, meshNamespace, smcpName)
 	}
 }
 


### PR DESCRIPTION
For 2.1 smcp version we need to restart deployments in meshNamespace