### PR TITLE
OSSM-3871 Fix Flaky test: TestCircuitBreaking

### DIFF
--- a/pkg/tests/tasks/traffic/circuit_breaking_test.go
+++ b/pkg/tests/tasks/traffic/circuit_breaking_test.go
@@ -73,10 +73,10 @@ func TestCircuitBreaking(t *testing.T) {
 			c200 := getNumberOfResponses(t, msg, `Code 200.*`)
 			c503 := getNumberOfResponses(t, msg, `Code 503.*`)
 			successRate200 := 100 * c200 / reqCount
-			successRate503 := 100 * c503 / reqCount
+			failureRate503 := 100 * c503 / reqCount
 			t.Log(fmt.Sprintf("Success rate 200: %d%%", successRate200))
-			t.Log(fmt.Sprintf("Success rate 503: %d%%", successRate503))
-			if successRate503 == 0 {
+			t.Log(fmt.Sprintf("Success rate 503: %d%%", failureRate503))
+			if failureRate503 > 5 {
 				t.Fatalf("Failed to trip the circuit breaker")
 			}
 

--- a/pkg/tests/tasks/traffic/circuit_breaking_test.go
+++ b/pkg/tests/tasks/traffic/circuit_breaking_test.go
@@ -69,7 +69,7 @@ func TestCircuitBreaking(t *testing.T) {
 			msg := oc.Exec(t,
 				pod.MatchingSelector("app=fortio", ns),
 				"fortio",
-				fmt.Sprintf("/usr/bin/fortio load -c %d -qps 0.1 -n %d -loglevel Warning http://httpbin:8000/get", connection, reqCount))
+				fmt.Sprintf("/usr/bin/fortio load -c %d -qps 4 -n %d -loglevel Warning http://httpbin:8000/get", connection, reqCount))
 
 			c200 := getNumberOfResponses(t, msg, `Code 200.*`)
 			c503 := getNumberOfResponses(t, msg, `Code 503.*`)

--- a/pkg/tests/tasks/traffic/circuit_breaking_test.go
+++ b/pkg/tests/tasks/traffic/circuit_breaking_test.go
@@ -138,9 +138,4 @@ spec:
       http:
         http1MaxPendingRequests: 1
         maxRequestsPerConnection: 1
-    outlierDetection:
-      consecutiveErrors: 1
-      interval: 1s
-      baseEjectionTime: 3m
-      maxEjectionPercent: 100
 `

--- a/pkg/tests/tasks/traffic/circuit_breaking_test.go
+++ b/pkg/tests/tasks/traffic/circuit_breaking_test.go
@@ -69,7 +69,7 @@ func TestCircuitBreaking(t *testing.T) {
 			msg := oc.Exec(t,
 				pod.MatchingSelector("app=fortio", ns),
 				"fortio",
-				fmt.Sprintf("/usr/bin/fortio load -c %d -qps 0 -n %d -loglevel Warning http://httpbin:8000/get", connection, reqCount))
+				fmt.Sprintf("/usr/bin/fortio load -c %d -qps 0.1 -n %d -loglevel Warning http://httpbin:8000/get", connection, reqCount))
 
 			c200 := getNumberOfResponses(t, msg, `Code 200.*`)
 			c503 := getNumberOfResponses(t, msg, `Code 503.*`)

--- a/pkg/tests/tasks/traffic/circuit_breaking_test.go
+++ b/pkg/tests/tasks/traffic/circuit_breaking_test.go
@@ -79,11 +79,11 @@ func TestCircuitBreaking(t *testing.T) {
 
 			t.LogStep("Validate the circuit breaker is tripped by checking the istio-proxy log")
 			t.Log("Verify istio-proxy pilot-agent stats, expected upstream_rq_pending_overflow value to be more than zero")
-			output := oc.Exec(t,
-				pod.MatchingSelector("app=fortio", ns),
-				"istio-proxy",
-				"pilot-agent request GET stats | grep httpbin | grep pending")
-			assertProxyContainsUpstreamRqPendingOverflow(t, output)
+	oc.Exec(t,
+		pod.MatchingSelector("app=fortio", ns),
+		"istio-proxy",
+		"pilot-agent request GET stats | grep httpbin | grep pending",
+		assertProxyContainsUpstreamRqPendingOverflow)
 		})
 	})
 }

--- a/pkg/tests/tasks/traffic/circuit_breaking_test.go
+++ b/pkg/tests/tasks/traffic/circuit_breaking_test.go
@@ -76,14 +76,17 @@ func TestCircuitBreaking(t *testing.T) {
 			successRate503 := 100 * c503 / reqCount
 			t.Log(fmt.Sprintf("Success rate 200: %d%%", successRate200))
 			t.Log(fmt.Sprintf("Success rate 503: %d%%", successRate503))
+			if successRate503 == 0 {
+				t.Fatalf("Failed to trip the circuit breaker")
+			}
 
 			t.LogStep("Validate the circuit breaker is tripped by checking the istio-proxy log")
 			t.Log("Verify istio-proxy pilot-agent stats, expected upstream_rq_pending_overflow value to be more than zero")
-	oc.Exec(t,
-		pod.MatchingSelector("app=fortio", ns),
-		"istio-proxy",
-		"pilot-agent request GET stats | grep httpbin | grep pending",
-		assertProxyContainsUpstreamRqPendingOverflow)
+			oc.Exec(t,
+				pod.MatchingSelector("app=fortio", ns),
+				"istio-proxy",
+				"pilot-agent request GET stats | grep httpbin | grep pending",
+				assertProxyContainsUpstreamRqPendingOverflow)
 		})
 	})
 }

--- a/pkg/tests/tasks/traffic/circuit_breaking_test.go
+++ b/pkg/tests/tasks/traffic/circuit_breaking_test.go
@@ -76,7 +76,7 @@ func TestCircuitBreaking(t *testing.T) {
 			failureRate503 := 100 * c503 / reqCount
 			t.Log(fmt.Sprintf("Success rate 200: %d%%", successRate200))
 			t.Log(fmt.Sprintf("Success rate 503: %d%%", failureRate503))
-			if failureRate503 > 5 {
+			if failureRate503 < 5 {
 				t.Fatalf("Failed to trip the circuit breaker")
 			}
 


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/OSSM-3871

**TestCircuitBreaking**: change the number of requests per second to adjust and avoid condition meet of failures, no will be 10 request per second to the DestinationRule defined:

```
  trafficPolicy:
    connectionPool:
      tcp:
        maxConnections: 1
      http:
        http1MaxPendingRequests: 1
        maxRequestsPerConnection: 1
    outlierDetection:
      consecutiveErrors: 1
      interval: 1s
      baseEjectionTime: 3m
      maxEjectionPercent: 100
```
