### PR TITLE
OSSM-3871 TestSMCPAnnotations flaky test

### DIFF
--- a/pkg/tests/ossm/deploy_on_infra_test.go
+++ b/pkg/tests/ossm/deploy_on_infra_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/pod"
 	"github.com/maistra/maistra-test-tool/pkg/util/retry"
 	"github.com/maistra/maistra-test-tool/pkg/util/shell"
-	. "github.com/maistra/maistra-test-tool/pkg/util/test"
+	"github.com/maistra/maistra-test-tool/pkg/util/test"
 	"github.com/maistra/maistra-test-tool/pkg/util/version"
 )
 

--- a/pkg/tests/ossm/deploy_on_infra_test.go
+++ b/pkg/tests/ossm/deploy_on_infra_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/pod"
 	"github.com/maistra/maistra-test-tool/pkg/util/retry"
 	"github.com/maistra/maistra-test-tool/pkg/util/shell"
-	"github.com/maistra/maistra-test-tool/pkg/util/test"
 	. "github.com/maistra/maistra-test-tool/pkg/util/test"
 	"github.com/maistra/maistra-test-tool/pkg/util/version"
 )
@@ -91,7 +90,7 @@ spec:
 			oc.WaitPodReady(t, locator)
 			operatorPod := locator(t, oc.DefaultOC)
 
-			retry.UntilSuccess(t, func(t test.TestHelper) {
+			retry.UntilSuccess(t, func(t TestHelper) {
 				shell.Execute(t,
 					fmt.Sprintf(`oc get pod -n openshift-operators %s -o jsonpath='{.spec.nodeName}'`, operatorPod.Name),
 					assert.OutputContains(
@@ -112,7 +111,7 @@ spec:
 			DeployControlPlane(t)
 
 			t.LogStep("Patch SMCP to run all control plane components on infra nodes and wait for the SMCP to be ready")
-			retry.UntilSuccess(t, func(t test.TestHelper) {
+			retry.UntilSuccess(t, func(t TestHelper) {
 				oc.Patch(t, meshNamespace, "smcp", smcpName, "merge", `
 spec:
   runtime:
@@ -142,7 +141,7 @@ spec:
 }
 
 func assertPodScheduledToNode(t TestHelper, pLabel string) {
-	retry.UntilSuccess(t, func(t test.TestHelper) {
+	retry.UntilSuccess(t, func(t TestHelper) {
 		podLocator := pod.MatchingSelector(pLabel, meshNamespace)
 		po := podLocator(t, oc.DefaultOC)
 		shell.Execute(t,
@@ -154,7 +153,7 @@ func assertPodScheduledToNode(t TestHelper, pLabel string) {
 	})
 }
 
-func pickWorkerNode(t test.TestHelper) string {
+func pickWorkerNode(t TestHelper) string {
 	workerNodes := shell.Execute(t, "oc get nodes -l node-role.kubernetes.io/worker= -o jsonpath='{.items[*].metadata.name}'")
 	operatorNode := shell.Execute(t, "oc get pods -n openshift-operators -l name=istio-operator -o jsonpath='{.items[0].spec.nodeName}'")
 	for _, node := range strings.Split(workerNodes, "\n") {

--- a/pkg/tests/ossm/smcp_annotation_test.go
+++ b/pkg/tests/ossm/smcp_annotation_test.go
@@ -89,7 +89,7 @@ func GetPodAnnotations(t TestHelper, podLocator oc.PodLocatorFunc) map[string]st
 		if len(annotations) == 0 {
 			oc.DeletePod(t, podLocator)
 			oc.WaitPodReady(t, podLocator)
-			t.Fatalf("Pod annotations are empty")
+			t.Fatal("Pod annotations are empty")
 		}
 	})
 	return annotations

--- a/pkg/tests/ossm/smcp_annotation_test.go
+++ b/pkg/tests/ossm/smcp_annotation_test.go
@@ -89,7 +89,7 @@ func GetPodAnnotations(t TestHelper, podLocator oc.PodLocatorFunc) map[string]st
 		if len(annotations) == 0 {
 			oc.DeletePod(t, podLocator)
 			oc.WaitPodReady(t, podLocator)
-			t.Log("Pod annotations are empty")
+			t.Fatalf("Pod annotations are empty")
 		}
 	})
 	return annotations

--- a/pkg/tests/ossm/smcp_annotation_test.go
+++ b/pkg/tests/ossm/smcp_annotation_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/pod"
 	"github.com/maistra/maistra-test-tool/pkg/util/retry"
 	"github.com/maistra/maistra-test-tool/pkg/util/test"
-	. "github.com/maistra/maistra-test-tool/pkg/util/test"
 )
 
 func TestSMCPAnnotations(t *testing.T) {

--- a/pkg/tests/ossm/smcp_annotation_test.go
+++ b/pkg/tests/ossm/smcp_annotation_test.go
@@ -18,12 +18,13 @@ import (
 	_ "embed"
 	"testing"
 
+	"gopkg.in/yaml.v2"
+
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
 	"github.com/maistra/maistra-test-tool/pkg/util/pod"
 	"github.com/maistra/maistra-test-tool/pkg/util/retry"
 	"github.com/maistra/maistra-test-tool/pkg/util/test"
 	. "github.com/maistra/maistra-test-tool/pkg/util/test"
-	"gopkg.in/yaml.v2"
 )
 
 func TestSMCPAnnotations(t *testing.T) {

--- a/pkg/tests/ossm/smcp_annotation_test.go
+++ b/pkg/tests/ossm/smcp_annotation_test.go
@@ -44,7 +44,7 @@ func TestSMCPAnnotations(t *testing.T) {
 
 			t.LogStep("Get annotations and verify that the pod has the expected: sidecar.maistra.io/proxyEnv : { \"maistra_test_env\": \"env_value\", \"maistra_test_env_2\": \"env_value_2\" }")
 			annotations := VerifyAndGetPodAnnotation(t, pod.MatchingSelector("app=env", ns))
-			assertAnnotationIsPresent(t, pod.MatchingSelector("app=env", ns), annotations, "sidecar.maistra.io/proxyEnv", `{ "maistra_test_env": "env_value", "maistra_test_env_2": "env_value_2" }`)
+			assertAnnotationIsPresent(t, annotations, "sidecar.maistra.io/proxyEnv", `{ "maistra_test_env": "env_value", "maistra_test_env_2": "env_value_2" }`)
 		})
 
 		// Test that the SMCP automatic injection with quotes works
@@ -70,9 +70,9 @@ func TestSMCPAnnotations(t *testing.T) {
 			t.LogStep("Get annotations and verify that the pod has the expected: test1.annotation-from-smcp : test1, test2.annotation-from-smcp : [\"test2\"], test3.annotation-from-smcp : {test3}")
 			retry.UntilSuccess(t, func(t test.TestHelper) {
 				annotations := VerifyAndGetPodAnnotation(t, pod.MatchingSelector("app=env", ns))
-				assertAnnotationIsPresent(t, pod.MatchingSelector("app=env", ns), annotations, "test1.annotation-from-smcp", "test1")
-				assertAnnotationIsPresent(t, pod.MatchingSelector("app=env", ns), annotations, "test2.annotation-from-smcp", `["test2"]`)
-				assertAnnotationIsPresent(t, pod.MatchingSelector("app=env", ns), annotations, "test3.annotation-from-smcp", "{test3}")
+				assertAnnotationIsPresent(t, annotations, "test1.annotation-from-smcp", "test1")
+				assertAnnotationIsPresent(t, annotations, "test2.annotation-from-smcp", `["test2"]`)
+				assertAnnotationIsPresent(t, annotations, "test3.annotation-from-smcp", "{test3}")
 			})
 		})
 	})
@@ -102,10 +102,11 @@ func VerifyAndGetPodAnnotation(t test.TestHelper, podLocator oc.PodLocatorFunc) 
 	return annotations
 }
 
-func assertAnnotationIsPresent(t test.TestHelper, podLocator oc.PodLocatorFunc, annotations map[string]string, key string, expectedValue string) {
+func assertAnnotationIsPresent(t test.TestHelper, annotations map[string]string, key string, expectedValue string) {
+	locator := pod.MatchingSelector("app=env", "foo")
 	if annotations[key] != expectedValue {
-		oc.DeletePod(t, podLocator)
-		oc.WaitPodReady(t, podLocator)
+		oc.DeletePod(t, locator)
+		oc.WaitPodReady(t, locator)
 		t.Fatalf("Expected annotation %s=%s, but got %s", key, expectedValue, annotations[key])
 	}
 }

--- a/pkg/tests/ossm/smcp_annotation_test.go
+++ b/pkg/tests/ossm/smcp_annotation_test.go
@@ -37,7 +37,7 @@ func TestSMCPAnnotations(t *testing.T) {
 			t.Parallel()
 			ns := "foo"
 			t.Cleanup(func() {
-				oc.RecreateNamespace(t, ns)
+				oc.DeleteFromTemplate(t, ns, testSSLDeploymentWithAnnotation, nil)
 			})
 			t.LogStep("Deploy TestSSL pod with annotations sidecar.maistra.io/proxyEnv")
 			oc.ApplyTemplate(t, ns, testSSLDeploymentWithAnnotation, nil)
@@ -54,7 +54,7 @@ func TestSMCPAnnotations(t *testing.T) {
 			ns := "bar"
 			t.Cleanup(func() {
 				oc.Patch(t, meshNamespace, "smcp", smcpName, "json", `[{"op": "remove", "path": "/spec/proxy"}]`)
-				oc.RecreateNamespace(t, ns)
+				oc.DeleteFromTemplate(t, ns, testSSLDeploymentWithAnnotation, nil)
 			})
 			t.LogStep("Enable annotation auto injection in SMCP")
 			oc.Patch(t,
@@ -85,6 +85,9 @@ func GetPodAnnotations(t TestHelper, podLocator oc.PodLocatorFunc) map[string]st
 		err := json.Unmarshal([]byte(output), &annotations)
 		if err != nil {
 			t.Fatalf("Error parsing pod annotations json: %v", err)
+		}
+		if len(annotations) == 0 {
+			t.Fatal("Pod annotations are empty, retrying...")
 		}
 	})
 	return annotations

--- a/pkg/tests/ossm/smcp_annotation_test.go
+++ b/pkg/tests/ossm/smcp_annotation_test.go
@@ -87,7 +87,9 @@ func GetPodAnnotations(t TestHelper, podLocator oc.PodLocatorFunc) map[string]st
 			t.Fatalf("Error parsing pod annotations json: %v", err)
 		}
 		if len(annotations) == 0 {
-			t.Fatal("Pod annotations are empty, retrying...")
+			oc.DeletePod(t, podLocator)
+			oc.WaitPodReady(t, podLocator)
+			t.Log("Pod annotations are empty")
 		}
 	})
 	return annotations

--- a/pkg/tests/ossm/smcp_annotation_test.go
+++ b/pkg/tests/ossm/smcp_annotation_test.go
@@ -27,12 +27,12 @@ import (
 )
 
 func TestSMCPAnnotations(t *testing.T) {
-	NewTest(t).Id("T29").Groups(Full, Disconnected).Run(func(t TestHelper) {
+	test.NewTest(t).Id("T29").Groups(test.Full, test.Disconnected).Run(func(t test.TestHelper) {
 		t.Log("Test annotations: verify deployment with sidecar.maistra.io/proxyEnv annotations and Enable automatic injection in SMCP to propagate the annotations to the sidecar")
 
 		DeployControlPlane(t) // TODO: move this to individual subtests and integrate patch if one exists
 
-		t.NewSubTest("proxyEnvoy").Run(func(t TestHelper) {
+		t.NewSubTest("proxyEnvoy").Run(func(t test.TestHelper) {
 			t.Parallel()
 			ns := "foo"
 			t.Cleanup(func() {
@@ -48,7 +48,7 @@ func TestSMCPAnnotations(t *testing.T) {
 		})
 
 		// Test that the SMCP automatic injection with quotes works
-		t.NewSubTest("quote_injection").Run(func(t TestHelper) {
+		t.NewSubTest("quote_injection").Run(func(t test.TestHelper) {
 			t.Parallel()
 			ns := "bar"
 			t.Cleanup(func() {
@@ -78,7 +78,7 @@ func TestSMCPAnnotations(t *testing.T) {
 	})
 }
 
-func VerifyAndGetPodAnnotation(t TestHelper, podLocator oc.PodLocatorFunc) map[string]string {
+func VerifyAndGetPodAnnotation(t test.TestHelper, podLocator oc.PodLocatorFunc) map[string]string {
 	var data map[string]interface{}
 	po := podLocator(t, oc.DefaultOC)
 	yamlString := oc.GetYaml(t, po.Namespace, "pod", po.Name)
@@ -101,7 +101,7 @@ func VerifyAndGetPodAnnotation(t TestHelper, podLocator oc.PodLocatorFunc) map[s
 	return annotations
 }
 
-func assertAnnotationIsPresent(t TestHelper, podLocator oc.PodLocatorFunc, annotations map[string]string, key string, expectedValue string) {
+func assertAnnotationIsPresent(t test.TestHelper, podLocator oc.PodLocatorFunc, annotations map[string]string, key string, expectedValue string) {
 	if annotations[key] != expectedValue {
 		oc.DeletePod(t, podLocator)
 		oc.WaitPodReady(t, podLocator)


### PR DESCRIPTION
Jira:

TestSMCPAnnotations is flaky because the second sub-test case is getting empty annotations, made some changes:

- Improve clean up, it's flake test related but this will improve execution time
- Added a length check to fail and retry in annotation is equal to zero