### PR TITLE
OSSM-3871 Improve Apply String, template and file

### DIFF
--- a/pkg/util/test/test_helper_setup.go
+++ b/pkg/util/test/test_helper_setup.go
@@ -94,7 +94,7 @@ func (t *setupTestHelper) LogStepf(format string, args ...any) {
 }
 
 func (t *setupTestHelper) CurrentStep() int {
-	panic("not applicable")
+	return 0
 }
 
 func (t *setupTestHelper) LogSuccess(str string) {


### PR DESCRIPTION
To be able to fix some flaky tests as SingleClusterFederation I made some changes to func ApplyString and ApplyFile to make retries and log as Warning every time that a apply fails

Jira for flaky test: https://issues.redhat.com/browse/OSSM-3871?filter=12407518