### PR TITLE
Fix TestOpenShiftMonitoring

### DIFF
--- a/pkg/tests/tasks/observability/openshift_monitoring_test.go
+++ b/pkg/tests/tasks/observability/openshift_monitoring_test.go
@@ -114,7 +114,7 @@ func TestOpenShiftMonitoring(t *testing.T) {
 func checkMetricExists(t test.TestHelper, ns, metricName, token string) {
 	retry.UntilSuccess(t, func(t test.TestHelper) {
 		oc.Exec(t,
-			pod.MatchingSelector("app.kubernetes.io/instance=thanos-querier", monitoringNs),
+			pod.MatchingSelector("app.kubernetes.io/instance=thanos-querier", monitoringNs, true),
 			"thanos-query",
 			prometheusQuery(ns, metricName, token),
 			assert.OutputContains(

--- a/pkg/util/pod/pods.go
+++ b/pkg/util/pod/pods.go
@@ -7,7 +7,8 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/test"
 )
 
-func MatchingSelector(selector string, ns string) ocpackage.PodLocatorFunc {
+// MatchingSelector returns a function that returns the name of a pod matching the given selector in the given namespace. If more than one pod matches the selector, will fail unless  returnOnePod is true, then the first pod is returned even if more than one pod matches the selector.
+func MatchingSelector(selector string, ns string, returnOnePod ...bool) ocpackage.PodLocatorFunc {
 	return func(t test.TestHelper, oc *ocpackage.OC) ocpackage.NamespacedName {
 		t.T().Helper()
 		output := oc.Invokef(t, "kubectl -n %s get pods -l %q -o jsonpath='{.items[*].metadata.name}'", ns, selector)
@@ -16,6 +17,8 @@ func MatchingSelector(selector string, ns string) ocpackage.PodLocatorFunc {
 		}
 		pods := strings.Split(output, " ")
 		if len(pods) == 1 {
+			return ocpackage.NewNamespacedName(ns, pods[0])
+		} else if returnOnePod[0] && len(pods) > 1 {
 			return ocpackage.NewNamespacedName(ns, pods[0])
 		} else {
 			t.Fatalf("more than one pod found using selector %q in namespace %s: %v", selector, ns, pods)


### PR DESCRIPTION
When the tool is running in a multinode cluster you will have more than one Thanos pod, so I add an additional parameter (Instead of creating a specific func to this) to be able to return only one pod in pod.MatchingSelector when we needed it. This will be used only when is specifically needed and I add some comments to explain how it works