### PR TITLE
OSSM-3967 Fix Cert manager test cases

### DIFF
--- a/pkg/tests/tasks/security/certmanager/istio_csr_test.go
+++ b/pkg/tests/tasks/security/certmanager/istio_csr_test.go
@@ -27,6 +27,10 @@ func TestIstioCsr(t *testing.T) {
 		if smcpVer.LessThan(version.SMCP_2_4) {
 			t.Skip("istio-csr is not supported in SMCP older than v2.4")
 		}
+		ocpVersion := version.ParseOCPVersion(oc.GetOCPVersion(t))
+		if ocpVersion.LessThan(version.OCP_4_12) {
+			t.Skip("istio-csr is not supported in OCP older than v4.12")
+		}
 
 		meshValues := map[string]string{
 			"Name":    smcpName,

--- a/pkg/tests/tasks/security/certmanager/main_test.go
+++ b/pkg/tests/tasks/security/certmanager/main_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
 	"github.com/maistra/maistra-test-tool/pkg/util/pod"
 	"github.com/maistra/maistra-test-tool/pkg/util/test"
+	"github.com/maistra/maistra-test-tool/pkg/util/version"
 )
 
 var (
@@ -52,6 +53,14 @@ func setupCertManagerOperator(t test.TestHelper) {
 		oc.DeleteNamespace(t, certManagerOperatorNs)
 		oc.DeleteNamespace(t, certManagerNs)
 	})
+	//Validate OCP version, this test setup can't be executed in OCP versions less than 4.12
+	//More information in: https://57747--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-security.html#ossm-cert-manager-integration-istio_ossm-security
+	ocpVersion := version.ParseOCPVersion(oc.GetOCPVersion(t))
+	//Verify if the OCP version is less than 4.12
+	if ocpVersion.LessThan(version.OCP_4_12) {
+		t.Skip("This test setup can't be executed in OCP versions less than 4.12")
+	}
+
 	ossm.BasicSetup(t)
 
 	t.LogStep("Create namespace for cert-manager-operator")

--- a/pkg/tests/tasks/security/certmanager/main_test.go
+++ b/pkg/tests/tasks/security/certmanager/main_test.go
@@ -47,19 +47,21 @@ func TestMain(m *testing.M) {
 }
 
 func setupCertManagerOperator(t test.TestHelper) {
+	//Validate OCP version, this test setup can't be executed in OCP versions less than 4.12
+	//More information in: https://57747--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-security.html#ossm-cert-manager-integration-istio_ossm-security
+	ocpVersion := version.ParseOCPVersion(oc.GetOCPVersion(t))
+	//Verify if the OCP version is less than 4.12
+	if ocpVersion.LessThan(version.OCP_4_12) {
+		t.Log("WARNING: This test setup can't be executed in OCP versions less than 4.12")
+		return
+	}
+
 	t.Cleanup(func() {
 		oc.DeleteFromString(t, certManagerNs, rootCA)
 		oc.DeleteFromString(t, certManagerOperatorNs, certManagerOperator)
 		oc.DeleteNamespace(t, certManagerOperatorNs)
 		oc.DeleteNamespace(t, certManagerNs)
 	})
-	//Validate OCP version, this test setup can't be executed in OCP versions less than 4.12
-	//More information in: https://57747--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-security.html#ossm-cert-manager-integration-istio_ossm-security
-	ocpVersion := version.ParseOCPVersion(oc.GetOCPVersion(t))
-	//Verify if the OCP version is less than 4.12
-	if ocpVersion.LessThan(version.OCP_4_12) {
-		t.Skip("This test setup can't be executed in OCP versions less than 4.12")
-	}
 
 	ossm.BasicSetup(t)
 

--- a/pkg/tests/tasks/security/certmanager/plugin_ca_test.go
+++ b/pkg/tests/tasks/security/certmanager/plugin_ca_test.go
@@ -26,6 +26,10 @@ func TestPluginCaCert(t *testing.T) {
 		if smcpVer.LessThan(version.SMCP_2_4) {
 			t.Skip("istio-csr is not supported in SMCP older than v2.4")
 		}
+		ocpVersion := version.ParseOCPVersion(oc.GetOCPVersion(t))
+		if ocpVersion.LessThan(version.OCP_4_12) {
+			t.Skip("istio-csr is not supported in OCP older than v4.12")
+		}
 
 		meshValues := map[string]string{
 			"Name":    smcpName,

--- a/pkg/util/oc/oc.go
+++ b/pkg/util/oc/oc.go
@@ -16,6 +16,11 @@ func ApplyString(t test.TestHelper, ns string, yamls ...string) {
 	DefaultOC.ApplyString(t, ns, yamls...)
 }
 
+func GetOCPVersion(t test.TestHelper) string {
+	t.T().Helper()
+	return DefaultOC.GetOCPVersion(t)
+}
+
 func ReplaceOrApplyString(t test.TestHelper, ns string, yaml string) {
 	t.T().Helper()
 	DefaultOC.ReplaceOrApplyString(t, ns, yaml)

--- a/pkg/util/test/test_helper_setup.go
+++ b/pkg/util/test/test_helper_setup.go
@@ -40,6 +40,7 @@ func (t *setupTestHelper) Failed() bool {
 }
 
 func (t *setupTestHelper) Skip(args ...any) {
+	t.t.Helper()
 	t.t.Skip(args...)
 }
 

--- a/pkg/util/test/test_helper_setup.go
+++ b/pkg/util/test/test_helper_setup.go
@@ -40,7 +40,7 @@ func (t *setupTestHelper) Failed() bool {
 }
 
 func (t *setupTestHelper) Skip(args ...any) {
-	panic("not applicable")
+	t.t.Skip(args...)
 }
 
 func (t *setupTestHelper) Skipf(format string, args ...any) {

--- a/pkg/util/version/version.go
+++ b/pkg/util/version/version.go
@@ -13,12 +13,25 @@ var (
 	SMCP_2_3 = ParseVersion("v2.3")
 	SMCP_2_4 = ParseVersion("v2.4")
 
+	OCP_4_9  = ParseOCPVersion("4.9.0")
+	OCP_4_10 = ParseOCPVersion("4.10.0")
+	OCP_4_11 = ParseOCPVersion("4.11.0")
+	OCP_4_12 = ParseOCPVersion("4.12.0")
+	OCP_4_13 = ParseOCPVersion("4.13.0")
+	OCP_4_14 = ParseOCPVersion("4.14.0")
+
 	VERSIONS = []*Version{
 		&SMCP_2_0,
 		&SMCP_2_1,
 		&SMCP_2_2,
 		&SMCP_2_3,
 		&SMCP_2_4,
+		&OCP_4_9,
+		&OCP_4_10,
+		&OCP_4_11,
+		&OCP_4_12,
+		&OCP_4_13,
+		&OCP_4_14,
 	}
 )
 
@@ -44,6 +57,23 @@ func ParseVersion(version string) Version {
 		panic(fmt.Sprintf("invalid SMCP version: %s", version))
 	}
 
+	return Version{Major: major, Minor: minor}
+}
+
+func ParseOCPVersion(version string) Version {
+	// OCP version is in the form of "major.minor.patch", example: 4.10.59
+	majorMinorPatch := strings.Split(version, ".")
+	if len(majorMinorPatch) != 3 {
+		panic(fmt.Sprintf("invalid OCP version: %s", version))
+	}
+	major, err := strconv.Atoi(majorMinorPatch[0])
+	if err != nil {
+		panic(fmt.Sprintf("invalid OCP version: %s", version))
+	}
+	minor, err := strconv.Atoi(majorMinorPatch[1])
+	if err != nil {
+		panic(fmt.Sprintf("invalid OCP version: %s", version))
+	}
 	return Version{Major: major, Minor: minor}
 }
 


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/OSSM-3967

Added a ocp check version to get the version and skipped in test cases that does not work with some OCP version