### PR TITLE
Add TestPrometheusExtensionProvider

### DIFF
--- a/pkg/tests/tasks/observability/custom_prometheus_test.go
+++ b/pkg/tests/tasks/observability/custom_prometheus_test.go
@@ -1,0 +1,396 @@
+package observability
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/maistra/maistra-test-tool/pkg/app"
+	"github.com/maistra/maistra-test-tool/pkg/util/check/assert"
+	"github.com/maistra/maistra-test-tool/pkg/util/check/common"
+	"github.com/maistra/maistra-test-tool/pkg/util/curl"
+	"github.com/maistra/maistra-test-tool/pkg/util/env"
+	"github.com/maistra/maistra-test-tool/pkg/util/ns"
+	"github.com/maistra/maistra-test-tool/pkg/util/oc"
+	"github.com/maistra/maistra-test-tool/pkg/util/pod"
+	"github.com/maistra/maistra-test-tool/pkg/util/retry"
+	"github.com/maistra/maistra-test-tool/pkg/util/test"
+	"github.com/maistra/maistra-test-tool/pkg/util/version"
+)
+
+func TestCustomPrometheus(t *testing.T) {
+	const customPrometheusNs = "custom-prometheus"
+
+	test.NewTest(t).Id("custom-prometheus").Groups(test.Full).Run(func(t test.TestHelper) {
+		smcpVer := env.GetSMCPVersion()
+		if smcpVer.LessThan(version.SMCP_2_4) {
+			t.Skip("Extension providers are not supported in OSSM older than v2.4.0")
+		}
+
+		t.Cleanup(func() {
+			oc.RecreateNamespace(t, ns.Bookinfo)
+			oc.RecreateNamespace(t, meshNamespace)
+			oc.DeleteNamespace(t, customPrometheusNs)
+
+			// HACK: workaround for a bug with the OLM CSV cache (possibly OCPBUGS-5080)
+			// the bug is preventing re-installing prometheus again on the same cluster unless the cache is cleared
+			oc.DeletePod(t, pod.MatchingSelector("app=catalog-operator", "openshift-operator-lifecycle-manager"))
+			oc.DeletePod(t, pod.MatchingSelector("app=olm-operator", "openshift-operator-lifecycle-manager"))
+		})
+
+		t.LogStep("Installing Prometheus operator")
+		oc.CreateNamespace(t, customPrometheusNs)
+		installPrometheusOperator(t, customPrometheusNs)
+
+		t.LogStep("Creating SMCP with Prometheus extension provider")
+		createSmcpWithPrometheusExtensionProvider(t, meshNamespace, customPrometheusNs, ns.Bookinfo)
+
+		t.LogStep("Installing custom Prometheus")
+		installPrometheus(t, customPrometheusNs, meshNamespace, ns.Bookinfo)
+
+		t.LogStep("Intalling Bookinfo app")
+		oc.WaitSMCPReady(t, meshNamespace, "basic")
+		bookinfoApp := app.Bookinfo(ns.Bookinfo)
+		bookinfoApp.Install(t)
+
+		t.LogStep("Enabling telemetry")
+		enablePrometheusTelemetry(t, meshNamespace)
+
+		t.LogStep("Enabling monitoring")
+		enableIstiodMonitoring(t, customPrometheusNs, meshNamespace)
+		enableIstioProxiesMonitoring(t, customPrometheusNs, meshNamespace, ns.Bookinfo)
+		enableAppMtlsMonitoring(t, customPrometheusNs, ns.Bookinfo)
+
+		t.LogStep("Waiting for installs to complete")
+		ocWaitOperatorInstall(t, customPrometheusNs, "rhods-prometheus-operator")
+		oc.WaitPodReady(t, pod.MatchingSelector("prometheus=prometheus", customPrometheusNs))
+		bookinfoApp.WaitReady(t)
+
+		t.LogStep("Sending request to Bookinfo app")
+		retry.UntilSuccess(t, func(t test.TestHelper) {
+			curl.Request(t, app.BookinfoProductPageURL(t, meshNamespace), nil, assert.ResponseStatus(http.StatusOK))
+		})
+
+		t.LogStep("Testing if telemetry was enabled")
+		ocWaitJsonpath(t, meshNamespace, "smcp", "basic",
+			"{.status.appliedValues.istio.telemetry.enabled}", "true",
+			"Telemetry was enabled.", "Telemetry failed to enable.")
+
+		t.LogStep("Testing if 'istio_requests_total' metric is available through Prometheus API")
+		retry.UntilSuccess(t, func(t test.TestHelper) {
+			var apiResp struct {
+				Data struct {
+					Result []interface{} `json:"result"`
+				} `json:"data"`
+			}
+			resp := oc.Exec(t, pod.MatchingSelector("prometheus=prometheus", customPrometheusNs), "istio-proxy",
+				fmt.Sprintf(`curl -s -S -G --data-urlencode %s 'http://127.0.0.1:9090/api/v1/query'`,
+					shellArgf(`query=istio_requests_total{namespace="%s",container="istio-proxy",source_app="istio-ingressgateway",destination_app="productpage"}`, ns.Bookinfo)))
+			err := json.Unmarshal([]byte(resp), &apiResp)
+			if err != nil {
+				t.Fatalf("Error while parsing response from Prometheus API: %v", err)
+			}
+			if len(apiResp.Data.Result) == 0 {
+				t.Errorf("No data points received from Prometheus API")
+			}
+		})
+	})
+}
+
+// utility functions to consistently escape shell arguments for external commands
+func shellArg(s string) string {
+	return fmt.Sprintf("'%s'", strings.ReplaceAll(s, `'`, `'\''`))
+}
+func shellArgf(format string, a ...any) string {
+	return shellArg(fmt.Sprintf(format, a...))
+}
+
+func ocGetJsonpath(t test.TestHelper, ns, kind, name, jsonpath string, checks ...common.CheckFunc) string {
+	t.T().Helper()
+	cmd := fmt.Sprintf(`oc -n %s get %s -o %s`,
+		shellArg(ns), shellArgf("%s/%s", kind, name), shellArgf("jsonpath=%s", jsonpath))
+	return oc.DefaultOC.Invoke(t, cmd, checks...)
+}
+
+func ocWaitJsonpath(t test.TestHelper, ns, kind, name, jsonpath, expected, successMessage, failureMsg string) {
+	t.T().Helper()
+	timeout := "1s"
+	cmd := fmt.Sprintf(`oc -n %s wait %s --for %s --timeout %s`,
+		shellArg(ns), shellArgf("%s/%s", kind, name), shellArgf("jsonpath=%s=%s", jsonpath, expected), timeout)
+	retry.UntilSuccess(t, func(t test.TestHelper) {
+		oc.DefaultOC.Invoke(t, cmd, assert.OutputContains(" condition met\n", successMessage, failureMsg))
+	})
+}
+
+func ocWaitOperatorInstall(t test.TestHelper, ns, subscriptionName string) {
+	t.T().Helper()
+	ocWaitJsonpath(t, ns, "subscription", subscriptionName,
+		"{.status.installPlanRef.kind}", "InstallPlan",
+		"Install plan was created.", "Wait for install plan failed.")
+	installPlanName := ocGetJsonpath(t, ns, "subscription", subscriptionName, "{.status.installPlanRef.name}")
+	oc.WaitCondition(t, ns, "installplan", installPlanName, "Installed")
+}
+
+func installPrometheusOperator(t test.TestHelper, ns string) {
+	t.T().Helper()
+	oc.ApplyString(t, ns,
+		fmt.Sprintf(`
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: custom-prometheus-operators
+spec:
+  targetNamespaces:
+    - %s`,
+			ns),
+		`
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: rhods-prometheus-operator
+spec:
+  channel: beta
+  name: rhods-prometheus-operator
+  source: redhat-operators 
+  sourceNamespace: openshift-marketplace`)
+}
+
+func createSmcpWithPrometheusExtensionProvider(t test.TestHelper, smcpNs, prometheusNs, additionalSmmrNs string) {
+	t.T().Helper()
+	oc.ApplyString(t, smcpNs, `
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+metadata:
+  name: basic
+spec:
+  addons:
+    grafana:
+      enabled: false
+    kiali:
+      enabled: false
+    prometheus:
+      enabled: false
+  extensionProviders:
+  - name: prometheus
+    prometheus: {}
+  gateways:
+    egress:
+      enabled: false
+    openshiftRoute:
+      enabled: false
+  proxy:
+    accessLogging:
+      file:
+        name: /dev/stdout
+  security:
+    dataPlane:
+      mtls: true
+  tracing:
+    type: None`,
+		fmt.Sprintf(`
+apiVersion: maistra.io/v1
+kind: ServiceMeshMemberRoll
+metadata:
+  name: default
+spec:
+  members:
+  - %s
+  - %s`,
+			prometheusNs,
+			additionalSmmrNs))
+}
+
+func installPrometheus(t test.TestHelper, ns string, permittedNs ...string) {
+	t.T().Helper()
+	oc.ApplyString(t, ns,
+		fmt.Sprintf(`
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: prometheus
+spec:
+  securityContext: {}
+  serviceAccountName: prometheus-k8s
+  podMonitorSelector: {}
+  podMonitorNamespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: %s
+  serviceMonitorSelector: {}
+  serviceMonitorNamespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: %s
+  podMetadata:
+    annotations:
+      sidecar.istio.io/inject: "true"
+      traffic.sidecar.istio.io/includeInboundPorts: ""
+      traffic.sidecar.istio.io/includeOutboundIPRanges: ""
+      proxy.istio.io/config: |
+        proxyMetadata:
+          OUTPUT_CERTS: /etc/istio-output-certs
+      sidecar.istio.io/userVolumeMount: '[{"name": "istio-certs", "mountPath": "/etc/istio-output-certs"}]'
+  volumes:
+  - name: istio-certs
+    emptyDir:
+      medium: Memory
+  volumeMounts:
+  - mountPath: /etc/prom-certs/
+    name: istio-certs`,
+			ns,
+			ns))
+
+	for _, permitNs := range permittedNs {
+		oc.ApplyString(t, permitNs,
+			`
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: custom-prometheus-permissions
+rules:
+- apiGroups: [""]
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["get"]`,
+			fmt.Sprintf(`
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: custom-prometheus-permissions
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: custom-prometheus-permissions
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: %s`,
+				ns))
+	}
+}
+
+func enablePrometheusTelemetry(t test.TestHelper, smcpNs string) {
+	t.T().Helper()
+	oc.ApplyString(t, smcpNs, `
+apiVersion: telemetry.istio.io/v1alpha1
+kind: Telemetry
+metadata:
+  name: enable-prometheus-metrics
+spec:
+  metrics:
+  - providers:
+    - name: prometheus
+`)
+}
+
+func enableIstiodMonitoring(t test.TestHelper, prometheusNs, smcpNs string) {
+	t.T().Helper()
+	oc.ApplyString(t, prometheusNs,
+		fmt.Sprintf(`
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: istiod-monitor
+spec:
+  targetLabels:
+  - app
+  selector:
+    matchLabels:
+      istio: pilot
+  namespaceSelector:
+    matchNames:
+      - %s
+  endpoints:
+  - port: http-monitoring
+    interval: 15s
+    path: /metrics`,
+			smcpNs))
+}
+
+func enableIstioProxiesMonitoring(t test.TestHelper, prometheusNs, smcpNs, additionalNs string) {
+	t.T().Helper()
+	oc.ApplyString(t, prometheusNs,
+		fmt.Sprintf(`
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: istio-proxies-monitor
+spec:
+  selector:
+    matchExpressions:
+    - key: istio-prometheus-ignore
+      operator: DoesNotExist
+  namespaceSelector:
+    matchNames:
+    - %s
+    - %s
+  podMetricsEndpoints:
+  - path: /stats/prometheus
+    interval: 15s
+    relabelings:
+    - action: keep
+      sourceLabels: [ __meta_kubernetes_pod_container_name ]
+      regex: "istio-proxy"
+    - action: keep
+      sourceLabels: [ __meta_kubernetes_pod_annotationpresent_prometheus_io_scrape ]
+    - action: replace
+      regex: (\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})
+      replacement: '[$2]:$1'
+      sourceLabels: [__meta_kubernetes_pod_annotation_prometheus_io_port, __meta_kubernetes_pod_ip]
+      targetLabel: __address__
+    - action: replace
+      regex: (\d+);((([0-9]+?)(\.|$)){4})
+      replacement: $2:$1
+      sourceLabels: [__meta_kubernetes_pod_annotation_prometheus_io_port, __meta_kubernetes_pod_ip]
+      targetLabel: __address__
+    - action: labeldrop
+      regex: "__meta_kubernetes_pod_label_(.+)"
+    - sourceLabels: [ __meta_kubernetes_namespace ]
+      action: replace
+      targetLabel: namespace
+    - sourceLabels: [ __meta_kubernetes_pod_name ]
+      action: replace
+      targetLabel: pod_name
+    - action: replace
+      replacement: "basic_%s"
+      targetLabel: mesh_id`,
+			smcpNs,
+			additionalNs,
+			smcpNs))
+}
+
+func enableAppMtlsMonitoring(t test.TestHelper, prometheusNs, bookinfoNs string) {
+	t.T().Helper()
+	oc.ApplyString(t, prometheusNs,
+		fmt.Sprintf(`
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: app-metrics-monitor-mtls
+spec:
+  targetLabels:
+  - app
+  selector:
+    matchLabels:
+      app: productpage
+  namespaceSelector:
+    matchNames:
+    - %s
+  endpoints:
+  - port: http
+    path: /metrics
+    interval: 15s
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prom-certs/root-cert.pem
+      certFile: /etc/prom-certs/cert-chain.pem
+      keyFile: /etc/prom-certs/key.pem
+      insecureSkipVerify: true`,
+			bookinfoNs))
+}


### PR DESCRIPTION
# TestCustomPrometheus

Added ~~TestPrometheusExtensionProvider~~ TestCustomPrometheus to test [OSSM-3288](https://issues.redhat.com/browse/OSSM-3288).

Currently this test has a couple of issues:

- ~~We need to use a custom bookinfo-productpage container image. I currently achieve this by directly modifying `app.BookinfoTemplate` and restoring it in `Cleanup`. Other options would be:~~
  - ~~deploy bookinfo manually and not leverage the `app` package.~~
  - ~~add some mechanism to hook into `template.image`.~~
- There appears to be a bug affecting the uninstall of the Prometheus operator currently. In the test I effectively uninstall the operator by deleting the namespace it is contained in, but I have also tested removing it according to OpenShift documentation by first removing the Subscription and then the ClusterServiceVersion (CSV). In both cases, the operator refuses to install again on the same cluster with an error indicating that a conflicting CSV is already installed. It appears the CSV is cached and the cache is not updated when the actual CSV is removed. After looking into the issue, it appears to be the same or similar to [OCPBUGS-5080](https://issues.redhat.com/browse/OCPBUGS-5080). I have placed a workaround into the `Cleanup` function for the test that effectively clears the cache by restarting a couple pods.

I added a few utility functions to this test that I felt might fit in in the `oc` package:

- `ocGetJsonpath`: I feel using a jsonpath expression directly in the query is much easier to read than using `oc.GetJson` and parsing the result, particularly when you are fetching a primitive value.
- `ocWaitJsonpath`: This one might be more niche or might be better implemented by simply repeatedly calling `ocGetJsonpath` in a loop, but oc/kubectl have functionality to wait on a jsonpath expression that I needed a couple of times in this test.
- `ocWaitOperatorInstall`: This one may also be fairly niche, but I needed to wait for an operator to be installed in this test and simply attempting to wait for pods in the operator's namespace to be ready did not work.
- ~~`ocOpenPortForward`: I needed to communicate with the Prometheus instance directly in this test and found that simply port forwarding via oc would make the test much simpler than adding everything needed to access it via the istio ingressgateway. The utility function itself is a bit lengthy because there is no way to meaningfully leverage the `exec` package to spin up a background process presently. One option to make this function simpler would be to use the existing `exec` functionality to execute a shell command that spins up the background process, returns the PID, and uses files to capture stdin/stdout, but I felt this was still complicated enough that it was better to just implement it in go directly.~~
