### PR TITLE
Fix TestPluginCaCert

### DIFF
--- a/pkg/tests/tasks/security/certmanager/plugin_ca_test.go
+++ b/pkg/tests/tasks/security/certmanager/plugin_ca_test.go
@@ -31,11 +31,12 @@ func TestPluginCaCert(t *testing.T) {
 			t.Skip("istio-csr is not supported in OCP older than v4.12")
 		}
 
-		meshValues := map[string]string{
+		meshValues := map[string]interface{}{
 			"Name":    smcpName,
 			"MeshNs":  meshNamespace,
 			"Member":  ns.Foo,
 			"Version": smcpVer.String(),
+			"Rosa":    env.IsRosa(),
 		}
 
 		t.Cleanup(func() {

--- a/pkg/tests/tasks/security/certmanager/yaml/cacerts/mesh.yaml
+++ b/pkg/tests/tasks/security/certmanager/yaml/cacerts/mesh.yaml
@@ -28,6 +28,10 @@ spec:
   security:
     dataPlane:
       mtls: true
+  {{ if .Rosa }} 
+    identity:
+      type: ThirdParty
+  {{ end }}
   tracing:
     type: None
   version: {{ .Version }}


### PR DESCRIPTION
For ROSA this test case was failing because we need to set: 
```
identity:
      type: ThirdParty
```