### PR TITLE
OSSM-3420: Fix TestCircuitBreaking in IPv6 stack

### DIFF
--- a/pkg/tests/ossm/yaml/smcp.yaml
+++ b/pkg/tests/ossm/yaml/smcp.yaml
@@ -20,6 +20,10 @@ spec:
       enabled: true
     prometheus:
       enabled: true
+  proxy:
+    accessLogging:
+      file:
+        name: /dev/stdout
   telemetry:
     type: Istiod
   {{ if .Rosa }} 

--- a/pkg/tests/tasks/traffic/circuit_breaking_test.go
+++ b/pkg/tests/tasks/traffic/circuit_breaking_test.go
@@ -51,7 +51,7 @@ func TestCircuitBreaking(t *testing.T) {
 
 		t.LogStep("Verify connection with curl: expect 200 OK")
 		retry.UntilSuccess(t, func(t test.TestHelper) {
-			httpbinIP := oc.GetPodIP(t, pod.MatchingSelector("app=httpbin", ns))
+			httpbinIP := oc.GetServiceClusterIP(t, ns, "httpbin")
 			oc.Exec(t,
 				pod.MatchingSelector("app=fortio", ns),
 				"fortio",
@@ -66,7 +66,7 @@ func TestCircuitBreaking(t *testing.T) {
 		t.LogStep("Trip the circuit breaker by sending 50 requests to httpbin with 2 connections")
 		t.Log("We expect request with response code 503")
 		retry.UntilSuccess(t, func(t test.TestHelper) {
-			httpbinIP := oc.GetPodIP(t, pod.MatchingSelector("app=httpbin", ns))
+			httpbinIP := oc.GetServiceClusterIP(t, ns, "httpbin")
 			msg := oc.Exec(t,
 				pod.MatchingSelector("app=fortio", ns),
 				"fortio",

--- a/pkg/tests/tasks/traffic/circuit_breaking_test.go
+++ b/pkg/tests/tasks/traffic/circuit_breaking_test.go
@@ -51,10 +51,11 @@ func TestCircuitBreaking(t *testing.T) {
 
 		t.LogStep("Verify connection with curl: expect 200 OK")
 		retry.UntilSuccess(t, func(t test.TestHelper) {
+			httpbinIP := oc.GetPodIP(t, pod.MatchingSelector("app=httpbin", ns))
 			oc.Exec(t,
 				pod.MatchingSelector("app=fortio", ns),
 				"fortio",
-				"/usr/bin/fortio curl -quiet http://httpbin:8000/get",
+				fmt.Sprintf(`/usr/bin/fortio curl -quiet -resolve %s http://httpbin:8000/get`, httpbinIP),
 				assert.OutputContains("200",
 					"Got expected 200 OK response from httpbin",
 					"Expected 200 OK from httpbin, but got an unexpected response"))
@@ -65,10 +66,11 @@ func TestCircuitBreaking(t *testing.T) {
 		t.LogStep("Trip the circuit breaker by sending 50 requests to httpbin with 2 connections")
 		t.Log("We expect request with response code 503")
 		retry.UntilSuccess(t, func(t test.TestHelper) {
+			httpbinIP := oc.GetPodIP(t, pod.MatchingSelector("app=httpbin", ns))
 			msg := oc.Exec(t,
 				pod.MatchingSelector("app=fortio", ns),
 				"fortio",
-				fmt.Sprintf("/usr/bin/fortio load -c %d -qps 0 -n %d -loglevel Warning http://httpbin:8000/get", connection, reqCount))
+				fmt.Sprintf("/usr/bin/fortio load -c %d -qps 0 -n %d -loglevel Warning -resolve %s http://httpbin:8000/get", connection, reqCount, httpbinIP))
 
 			c200 := getNumberOfResponses(t, msg, `Code 200.*`)
 			c503 := getNumberOfResponses(t, msg, `Code 503.*`)

--- a/pkg/util/oc/oc.go
+++ b/pkg/util/oc/oc.go
@@ -126,6 +126,11 @@ func GetPodIP(t test.TestHelper, podLocator PodLocatorFunc) string {
 	return DefaultOC.GetPodIP(t, podLocator)
 }
 
+func GetServiceClusterIP(t test.TestHelper, ns, serviceName string) string {
+	t.T().Helper()
+	return DefaultOC.GetServiceClusterIP(t, ns, serviceName)
+}
+
 func Logs(t test.TestHelper, podLocator PodLocatorFunc, container string, checks ...common.CheckFunc) {
 	t.T().Helper()
 	DefaultOC.Logs(t, podLocator, container, checks...)

--- a/pkg/util/oc/service_commands.go
+++ b/pkg/util/oc/service_commands.go
@@ -1,0 +1,12 @@
+package oc
+
+import (
+	"fmt"
+
+	"github.com/maistra/maistra-test-tool/pkg/util/test"
+)
+
+func (o OC) GetServiceClusterIP(t test.TestHelper, ns, serviceName string) string {
+	t.T().Helper()
+	return o.Invoke(t, fmt.Sprintf("kubectl get service -n %s %s -o jsonpath='{.spec.clusterIP}'", ns, serviceName))
+}


### PR DESCRIPTION
The tool fortio that is used in the test, resolves hostnames to IPv4 address by default and therefore the test was failing on IPv6 cluster. As you can see on the screenshot, fortio queries DNS for A records, not A and AAAA, so requests were failing.

![Screenshot from 2023-05-24 22-44-12](https://github.com/maistra/maistra-test-tool/assets/17457695/561def28-445f-4a37-b02c-ab2da2af8ef2)