### PR TITLE
OSSM-3418: Fix TestAuthPolicy on IPv6 stack

### DIFF
--- a/pkg/tests/ossm/yaml/smcp.yaml
+++ b/pkg/tests/ossm/yaml/smcp.yaml
@@ -24,6 +24,16 @@ spec:
     accessLogging:
       file:
         name: /dev/stdout
+  {{ if .ClusterWideProxy }}
+  runtime:
+    components:
+      pilot:
+        container:
+          env:
+            HTTP_PROXY: {{ .HttpProxy }}
+            HTTPS_PROXY: {{ .HttpsProxy }}
+            NO_PROXY: {{ .NoProxy }}
+  {{ end }}
   telemetry:
     type: Istiod
   {{ if .Rosa }} 

--- a/pkg/util/oc/oc.go
+++ b/pkg/util/oc/oc.go
@@ -242,7 +242,7 @@ func GetJson(t test.TestHelper, ns, kind, name string, checks ...common.CheckFun
 	return DefaultOC.GetJson(t, ns, kind, name, checks...)
 }
 
-func GetProxy(t test.TestHelper) Proxy {
+func GetProxy(t test.TestHelper) *Proxy {
 	t.T().Helper()
 	return DefaultOC.GetProxy(t)
 }

--- a/pkg/util/oc/oc_struct.go
+++ b/pkg/util/oc/oc_struct.go
@@ -433,9 +433,9 @@ func (o OC) GetJson(t test.TestHelper, ns, kind, name string, checks ...common.C
 }
 
 // GetProxy returns the Proxy object from the cluster
-func (o OC) GetProxy(t test.TestHelper) Proxy {
+func (o OC) GetProxy(t test.TestHelper) *Proxy {
 	type ProxyResource struct {
-		Status Proxy `json:"status"`
+		Status *Proxy `json:"status"`
 	}
 
 	proxyResource := ProxyResource{}


### PR DESCRIPTION
TestAuthPolicy was failing, because istiod could not properly process RequestAuthentication object due to networking issue:
```
error model Failed to refresh JWT public key from "https://raw.githubusercontent.com/istio/istio/release-1.9/security/tools/jwt/samples/jwks.json": Get "https://raw.githubusercontent.com/istio/istio/release-1.9/security/tools/jwt/samples/jwks.json": dial tcp [<ipv6_address>]:443: connect: no route to host
warn model Failed to GET from "https://raw.githubusercontent.com/istio/istio/release-1.9/security/tools/jwt/samples/jwks.json": Get "https://raw.githubusercontent.com/istio/istio/release-1.9/security/tools/jwt/samples/jwks.json": dial tcp [<ipv6_address>]:443: connect: no route to host. Retry in 1s
```
Our IPv6 cluster requires proxying egress traffic through a dedicated proxy, so we have to configure istiod to respect *_PROXY envs and use that proxy when connecting to external services.