### PR TITLE
OSSM-3423: Fix TestSecureGateways on IPv6

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -78,7 +78,7 @@ testssl:
   z: quay.io/maistra/testssl:0.0-ibm-z
 
 helloworld:
-  x86: istio/examples-helloworld-v1
+  x86: quay.io/jewertow/examples-helloworld-v1
   p: quay.io/maistra/helloworld-v1:0.0-ibm-p
   z: quay.io/maistra/helloworld-v1:0.0-ibm-z
 


### PR DESCRIPTION
`TestSecureGateways` uses `image istio/examples-helloworld-v1:latest` that was built 6 years ago and does not support IPv6. I replaced that image with `quay.io/jewertow/examples-helloworld-v1:latest` that is built from the recent code implementation supporting IPv6. This is a temporary change and we will have to replace this image once the community image will be available. I will open an issue in Istio repository to rebuild and push that image.