### PR TITLE
Enable Sub test case: delete smcp in Smoke Test

### DIFF
--- a/pkg/tests/ossm/smoke_test.go
+++ b/pkg/tests/ossm/smoke_test.go
@@ -99,11 +99,10 @@ func TestSmoke(t *testing.T) {
 		t.NewSubTest(fmt.Sprintf("delete smcp %s", toVersion)).Run(func(t TestHelper) {
 			t.Logf("This test checks whether SMCP %s deletion delete all the resources", env.GetSMCPVersion())
 
-			t.LogStep("Delete SMCP and verify if this deletes all resources")
-			t.LogStep("Delete SMCP in namespace " + meshNamespace)
+			t.LogStepf("Delete SMCP and SMMR in namespace %s", meshNamespace)
 			oc.DeleteFromString(t, meshNamespace, GetSMMRTemplate())
 			DeleteSMCPVersion(t, meshNamespace, env.GetSMCPVersion())
-			t.Log("verify SMCP resources are deleted")
+			t.LogStep("verify SMCP resources are deleted")
 			retry.UntilSuccess(t, func(t TestHelper) {
 				oc.Get(t,
 					meshNamespace,

--- a/pkg/tests/ossm/smoke_test.go
+++ b/pkg/tests/ossm/smoke_test.go
@@ -187,21 +187,12 @@ func assertUninstallDeletesAllResources(t test.TestHelper, ver version.Version) 
 	oc.DeleteFromString(t, meshNamespace, GetSMMRTemplate())
 	DeleteSMCPVersion(t, meshNamespace, ver)
 	retry.UntilSuccess(t, func(t TestHelper) {
-		shell.Execute(t,
-			fmt.Sprintf("oc get smcp -n %s", meshNamespace),
+		oc.Get(t,
+			meshNamespace,
+			"smcp,pods,services", "",
 			assert.OutputContains("No resources found in",
-				"SMCP is deleted from namespace",
-				"Still waiting for smcp to be deleted from namespace"))
-		shell.Execute(t,
-			fmt.Sprintf("oc get pods -n %s", meshNamespace),
-			assert.OutputContains("No resources found in",
-				"Pods are deleted from namespace",
-				"Still waiting for pods to be deleted from namespace"))
-		shell.Execute(t,
-			fmt.Sprintf("oc get services -n %s", meshNamespace),
-			assert.OutputContains("No resources found in",
-				"Services are deleted from namespace",
-				"Still waiting for services to be deleted from namespace"))
+				"SMCP resources are deleted",
+				"Still waiting for resources to be deleted from namespace"))
 	})
 }
 

--- a/pkg/tests/ossm/smoke_test.go
+++ b/pkg/tests/ossm/smoke_test.go
@@ -97,7 +97,7 @@ func TestSmoke(t *testing.T) {
 		})
 
 		t.NewSubTest(fmt.Sprintf("delete smcp %s", toVersion)).Run(func(t TestHelper) {
-			t.Logf("This test checks whether SMCP %s deletion delete all the resources", env.GetSMCPVersion())
+			t.Logf("This test checks whether SMCP %s deletion deletes all the resources", env.GetSMCPVersion())
 
 			t.LogStepf("Delete SMCP and SMMR in namespace %s", meshNamespace)
 			oc.DeleteFromString(t, meshNamespace, GetSMMRTemplate())


### PR DESCRIPTION
Enable again the sub test case delete smcp with small changes:

- Now the validation of the deletion of the smcp is not done using oc.GetAllResources because the routes for bookinfo are not deleted (more info in: https://issues.redhat.com/browse/OSSM-4064)
- To validate the deletion the test case verifies: smcp does not exist, pods does not exists, services does not exist