### PR TITLE
Return empty proxy when status cluster proxy does not exist

### DIFF
--- a/pkg/util/oc/oc_struct.go
+++ b/pkg/util/oc/oc_struct.go
@@ -445,6 +445,9 @@ func (o OC) GetProxy(t test.TestHelper) *Proxy {
 	proxyJson := o.GetJson(t, "", "proxy", "cluster", "{.status}")
 
 	proxy := &Proxy{}
+	if proxyJson == "" {
+		return proxy
+	}
 	var data map[string]interface{}
 	err := json.Unmarshal([]byte(proxyJson), &data)
 	if err != nil {


### PR DESCRIPTION
Testing in ROSA cluster (created using cluster bot) I saw that the response to
```
oc get proxy cluster -o jsonpath='{.status}'
```
Can be an empty string, this case was not managed so I added validation to return an empty Proxy if proxyjson is empty. This needs to be done because our customer that wants to run the tool can have this type of issue