### PR TITLE
OSSM-4217 Fix issues with cert manager setup

### DIFF
--- a/pkg/metallb/install.go
+++ b/pkg/metallb/install.go
@@ -69,7 +69,7 @@ func installOperator(t test.TestHelper, oc oc.OC) {
 			t.Error("metallb-operator-controller-manager not found - waiting until exists")
 		}
 	})
-	oc.WaitCondition(t, ns.MetalLB, "deployments", "metallb-operator-controller-manager", "Available")
+	oc.WaitFor(t, ns.MetalLB, "deployments", "metallb-operator-controller-manager", "condition=Available")
 }
 
 func deployMetalLB(t test.TestHelper, oc oc.OC) {
@@ -86,7 +86,7 @@ func deployMetalLB(t test.TestHelper, oc oc.OC) {
 			t.Error("MetalLB controller not found - waiting until exists")
 		}
 	})
-	oc.WaitCondition(t, ns.MetalLB, "deployments", "controller", "Available")
+	oc.WaitFor(t, ns.MetalLB, "deployments", "controller", "condition=Available")
 }
 
 func createAddressPool(t test.TestHelper, oc oc.OC) {

--- a/pkg/tests/tasks/observability/custom_prometheus_test.go
+++ b/pkg/tests/tasks/observability/custom_prometheus_test.go
@@ -121,7 +121,7 @@ func ocWaitOperatorInstall(t test.TestHelper, ns, subscriptionName string) {
 		"{.status.installPlanRef.kind}", "InstallPlan",
 		"Install plan was created.", "Wait for install plan failed.")
 	installPlanName := ocGetJsonpath(t, ns, "subscription", subscriptionName, "{.status.installPlanRef.name}")
-	oc.WaitCondition(t, ns, "installplan", installPlanName, "Installed")
+	oc.WaitFor(t, ns, "installplan", installPlanName, "condition=Installed")
 }
 
 func installPrometheusOperator(t test.TestHelper, ns string) {

--- a/pkg/tests/tasks/observability/openshift_monitoring_test.go
+++ b/pkg/tests/tasks/observability/openshift_monitoring_test.go
@@ -100,7 +100,7 @@ func TestOpenShiftMonitoring(t *testing.T) {
 		oc.WaitSMCPReady(t, meshNamespace, smcpName)
 
 		t.LogStep("Wait until Kiali is ready")
-		oc.WaitCondition(t, meshNamespace, "Kiali", kialiName, "Successful")
+		oc.WaitFor(t, meshNamespace, "Kiali", kialiName, "condition=Successful")
 
 		t.LogStep("Verify that Kiali was reconciled by Istio Operator")
 		retry.UntilSuccess(t, func(t test.TestHelper) {

--- a/pkg/tests/tasks/security/certmanager/main_test.go
+++ b/pkg/tests/tasks/security/certmanager/main_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/env"
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
 	"github.com/maistra/maistra-test-tool/pkg/util/pod"
+	"github.com/maistra/maistra-test-tool/pkg/util/retry"
 	"github.com/maistra/maistra-test-tool/pkg/util/test"
 	"github.com/maistra/maistra-test-tool/pkg/util/version"
 )
@@ -72,8 +73,10 @@ func setupCertManagerOperator(t test.TestHelper) {
 
 	t.LogStep("Install cert-manager-operator")
 	oc.ApplyString(t, certManagerOperatorNs, certManagerOperator)
-	oc.WaitPodReady(t, pod.MatchingSelector("name=cert-manager-operator", certManagerOperatorNs))
-	oc.WaitPodReady(t, pod.MatchingSelector("app=cert-manager", certManagerNs))
+	retry.UntilSuccess(t, func(t test.TestHelper) {
+		oc.WaitPodReady(t, pod.MatchingSelector("name=cert-manager-operator", certManagerOperatorNs))
+		oc.WaitPodReady(t, pod.MatchingSelector("app=cert-manager", certManagerNs))
+	})
 
 	t.LogStep("Create root ca")
 	oc.ApplyString(t, certManagerNs, rootCA)

--- a/pkg/tests/tasks/security/certmanager/main_test.go
+++ b/pkg/tests/tasks/security/certmanager/main_test.go
@@ -2,16 +2,12 @@ package certmanager
 
 import (
 	_ "embed"
-	"fmt"
 	"testing"
 
 	"github.com/maistra/maistra-test-tool/pkg/tests/ossm"
-	"github.com/maistra/maistra-test-tool/pkg/util/check/assert"
 	"github.com/maistra/maistra-test-tool/pkg/util/env"
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
 	"github.com/maistra/maistra-test-tool/pkg/util/pod"
-	"github.com/maistra/maistra-test-tool/pkg/util/retry"
-	"github.com/maistra/maistra-test-tool/pkg/util/shell"
 	"github.com/maistra/maistra-test-tool/pkg/util/test"
 	"github.com/maistra/maistra-test-tool/pkg/util/version"
 )
@@ -85,11 +81,8 @@ func setupCertManagerOperator(t test.TestHelper) {
 
 func waitOperatorSucceded(t test.TestHelper, certManagerOperatorNs string) {
 	t.Log("Waiting for cert-manager-operator to succeed")
-	retry.UntilSuccess(t, func(t test.TestHelper) {
-		shell.Execute(t,
-			fmt.Sprintf("oc get csv %s -n %s -o jsonpath='{.status.phase}'", certmanagerVersion, certManagerOperatorNs),
-			assert.OutputContains("Succeeded", "Operator ready", "Failed to wait for cert-manager-operator to succeed"))
-	})
+
+	oc.WaitFor(t, certManagerOperatorNs, "csv", certmanagerVersion, "jsonpath='{.status.phase}'=Succeeded")
 	oc.WaitPodReady(t, pod.MatchingSelector("name=cert-manager-operator", certManagerOperatorNs))
 	oc.WaitPodReady(t, pod.MatchingSelector("app=cert-manager", certManagerNs))
 }

--- a/pkg/tests/tasks/security/certmanager/yaml/cert-manager-operator.yaml
+++ b/pkg/tests/tasks/security/certmanager/yaml/cert-manager-operator.yaml
@@ -18,4 +18,4 @@ spec:
   name: openshift-cert-manager-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: cert-manager-operator.v1.11.1
+  startingCSV: {{ .Version }}

--- a/pkg/tests/tasks/security/certmanager/yaml/cert-manager-operator.yaml
+++ b/pkg/tests/tasks/security/certmanager/yaml/cert-manager-operator.yaml
@@ -18,4 +18,4 @@ spec:
   name: openshift-cert-manager-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: cert-manager-operator.v1.10.2
+  startingCSV: cert-manager-operator.v1.11.1

--- a/pkg/util/oc/oc.go
+++ b/pkg/util/oc/oc.go
@@ -186,9 +186,9 @@ func DeletePodNoWait(t test.TestHelper, podLocator PodLocatorFunc) {
 	DefaultOC.DeletePodNoWait(t, podLocator)
 }
 
-func WaitCondition(t test.TestHelper, ns string, kind string, name string, condition string) {
+func WaitFor(t test.TestHelper, ns string, kind string, name string, forCondition string) {
 	t.T().Helper()
-	DefaultOC.WaitCondition(t, ns, kind, name, condition)
+	DefaultOC.WaitFor(t, ns, kind, name, forCondition)
 }
 
 func WaitSMMRReady(t test.TestHelper, ns string) {

--- a/pkg/util/oc/oc_struct.go
+++ b/pkg/util/oc/oc_struct.go
@@ -269,7 +269,7 @@ func (o OC) WaitSMCPReady(t test.TestHelper, ns string, name string) {
 	t.T().Helper()
 	o.withKubeconfig(t, func() {
 		t.T().Helper()
-		o.WaitCondition(t, ns, "smcp", name, "Ready")
+		o.WaitFor(t, ns, "smcp", name, "condition=Ready")
 	})
 }
 

--- a/pkg/util/oc/pod_commands.go
+++ b/pkg/util/oc/pod_commands.go
@@ -146,22 +146,22 @@ func (o OC) DeletePodNoWait(t test.TestHelper, podLocator PodLocatorFunc) {
 	shell.Executef(t, `oc -n %s delete pod %s --wait=false`, pod.Namespace, pod.Name)
 }
 
-// WaitCondition runs `oc wait` 30 times every 10 seconds. If the resource doesn't
+// WaitFor runs `oc wait` 30 times every 10 seconds. If the resource doesn't
 // reach the specified condition in the last attempt, the function logs the failure
-// and
-func (o OC) WaitCondition(t test.TestHelper, ns string, kind string, name string, condition string) {
+// ForCondition is the condition to wait for, e.g. "condition=Ready"
+func (o OC) WaitFor(t test.TestHelper, ns string, kind string, name string, forCondition string) {
 	t.T().Helper()
 	maxAttempts := 30
 	var attemptT *test.RetryTestHelper
 	for i := 0; i < maxAttempts; i++ {
-		t.Logf("Wait for condition %s on %s %s/%s...", condition, kind, ns, name)
+		t.Logf("Wait for condition %s on %s %s/%s...", forCondition, kind, ns, name)
 		attemptT = retry.Attempt(t, func(t test.TestHelper) {
 			t.T().Helper()
 			shell.Execute(t,
-				fmt.Sprintf(`oc wait -n %s %s/%s --for condition=%s --timeout %s`, ns, kind, name, condition, "10s"),
+				fmt.Sprintf(`oc wait -n %s %s/%s --for %s --timeout %s`, ns, kind, name, forCondition, "10s"),
 				require.OutputContains("condition met",
-					fmt.Sprintf("Condition %s met by %s %s/%s", condition, kind, ns, name),
-					fmt.Sprintf("Condition %s not met by %s %s/%s", condition, kind, ns, name)))
+					fmt.Sprintf("Condition %s met by %s %s/%s", forCondition, kind, ns, name),
+					fmt.Sprintf("Condition %s not met by %s %s/%s", forCondition, kind, ns, name)))
 		})
 		if !attemptT.Failed() {
 			attemptT.FlushLogBuffer()


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/OSSM-4217

We have two common issues in cert-manager related tests:

- Operator cert-manager does not install and never gets ready
- Fail in setup causes panic for the test run

The first was solved updated the version of the cert-manager to the latest stable because in OCP cluster 4.13 was not running because the 1.10 version was failing in that OCP version. The second was I added a workaround because the issue is that the cert-manager takes more than 60 seconds to be installed the first time, so I added a retry until success to retry until the cert-manager is correctly installed. Additionally to this we need to verify why the Setup test helper is finishing with panic and is not accepting to change to the same behavior than test helper (This will be checked in a separate Jira ticket)


Note: the installation with the cert-manager operator was tested in OCP 4.13 and ROSA OCP 4.12 also
