### PR TITLE
OSSM-4223 Fix target file in must gather test case

### DIFF
--- a/pkg/tests/ossm/smcp_must_gather_test.go
+++ b/pkg/tests/ossm/smcp_must_gather_test.go
@@ -124,7 +124,7 @@ func TestMustGather(t *testing.T) {
 				"**/namespaces/istio-system/istio-system.yaml",
 				"**/namespaces/bookinfo/bookinfo.yaml",
 				"**/namespaces/openshift-operators/openshift-operators.yaml",
-				"**/namespaces/*/rbac.authorization.k8s.io/rolebindings/istiod-clusterrole-basic-istio-system.yaml")
+				"**/namespaces/*/rbac.authorization.k8s.io/rolebindings/mesh-users.yaml")
 		})
 
 		t.NewSubTest("cluster service version files validation").Run(func(t TestHelper) {


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/OSSM-4223

To fix the flaky test case MustGather we change the target file in the folder role bindings of the istio-system namespace, now we are going to use mesh-user.yaml