### PR TITLE
OSSM-3837 Fix errors on TestDeployOnInfraNodes

### DIFF
--- a/pkg/tests/ossm/deploy_on_infra_test.go
+++ b/pkg/tests/ossm/deploy_on_infra_test.go
@@ -34,7 +34,7 @@ var workername string
 func TestDeployOnInfraNodes(t *testing.T) {
 	test.NewTest(t).Id("T40").Groups(test.Full, test.Disconnected).Run(func(t test.TestHelper) {
 		t.Log("This test verifies that the OSSM operator and Istio components can be configured to run on infrastructure nodes")
-		// t.Skip("Skipping test due to https://issues.redhat.com/browse/OSSM-3837")
+
 		if env.GetSMCPVersion().LessThan(version.SMCP_2_3) {
 			t.Skip("Deploy On Infra node is available in SMCP versions v2.3+")
 		}


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/OSSM-3837

This test case could not be executed in a test run because of some failures that made to be tainted bot worker nodes. Changes made:

- Revert to patch servicemeshoperator moved to clean upper func because was causing operator hangout because the taints are active when that sub test case finish
- Added a operator pod deletion because sometimes is not automatically moved (Opened a new jira to investigate this: https://issues.redhat.com/browse/OSSM-4260)
- Fix error on func pickWorkerNode. We were picking both worker nodes so both workers was taint and this causes failures