### PR TITLE
OSSM-4358 Change SingleCluster federation test to work with multicluster also

### DIFF
--- a/pkg/tests/ossm-federation/main_test.go
+++ b/pkg/tests/ossm-federation/main_test.go
@@ -3,10 +3,18 @@ package ossm_federation
 import (
 	"testing"
 
+	"github.com/maistra/maistra-test-tool/pkg/metallb"
+	"github.com/maistra/maistra-test-tool/pkg/util/env"
 	"github.com/maistra/maistra-test-tool/pkg/util/test"
 )
 
 func TestMain(m *testing.M) {
 	test.NewSuite(m).
+		Setup(func(t test.TestHelper) {
+			if env.IsMetalLBInternalIPEnabled() && !env.IsRosa() {
+				//Deploy MetalLB in both clusters only if MetalLB is enabled and the test is not running in ROSA
+				metallb.InstallIfNotExist(t, env.GetKubeconfig(), env.GetKubeconfig2())
+			}
+		}).
 		Run()
 }


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/OSSM-4358

This PR use the changes to be done in this PR by @jewertow : https://github.com/maistra/maistra-test-tool/pull/583. This deploy MetalLB when the variable METALLB_INTERNAL_IP_ENABLED is true. 

I made a few changes to be able to use both single cluster federation in Multicluster scenario also, so those test case are now called: TestFederationDifferentCerts and TestFederation, and they are executed as singlecluster when only 1 kubeconfig file is given and as multicluster when two kubeconf are given