### PR TITLE
OSSM-4357 skip custom prometheus test case on version older than 4.11

### DIFF
--- a/pkg/tests/tasks/observability/custom_prometheus_test.go
+++ b/pkg/tests/tasks/observability/custom_prometheus_test.go
@@ -28,6 +28,10 @@ func TestCustomPrometheus(t *testing.T) {
 		if smcpVer.LessThan(version.SMCP_2_4) {
 			t.Skip("Extension providers are not supported in OSSM older than v2.4.0")
 		}
+		ocpVersion := version.ParseVersion(oc.GetOCPVersion(t))
+		if ocpVersion.LessThan(version.OCP_4_11) {
+			t.Skip("Custom Prometheus operator from red hat is not supported in OCP older than v4.11")
+		}
 
 		t.Cleanup(func() {
 			oc.RecreateNamespace(t, ns.Bookinfo)


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/OSSM-4357

The case is not supported on OCP versions less than 4.10 because Prometheus Operator it's not available from red hat catalog