### PR TITLE
skip Deploy the Gateway-Controller Profile for version les than 2.4

### DIFF
--- a/pkg/tests/tasks/traffic/ingress/gatewayapi_test.go
+++ b/pkg/tests/tasks/traffic/ingress/gatewayapi_test.go
@@ -97,6 +97,9 @@ func TestGatewayApi(t *testing.T) {
 		})
 
 		t.NewSubTest("Deploy the Gateway-Controller Profile").Run(func(t test.TestHelper) {
+			if env.GetSMCPVersion().LessThan(version.SMCP_2_4) {
+				t.Skip("Gateway-Controller Profile was added in v2.4")
+			}
 
 			t.Cleanup(func() {
 				oc.RecreateNamespace(t, meshNamespace)


### PR DESCRIPTION
Gateway-Controller Profile it's not available in versions of SMCP less than 2.4. So I added a skip for that case