### PR TITLE
skip certmanager for IBM Z&P

### DIFF
--- a/pkg/tests/tasks/security/certmanager/istio_csr_test.go
+++ b/pkg/tests/tasks/security/certmanager/istio_csr_test.go
@@ -31,6 +31,9 @@ func TestIstioCsr(t *testing.T) {
 		if ocpVersion.LessThan(version.OCP_4_12) {
 			t.Skip("istio-csr is not supported in OCP older than v4.12")
 		}
+		if env.GetArch() == "z" || env.GetArch() == "p" {
+			t.Skip("istio-csr is not supported for IBM Z&P")
+		}
 
 		meshValues := map[string]string{
 			"Name":    smcpName,

--- a/pkg/tests/tasks/security/certmanager/main_test.go
+++ b/pkg/tests/tasks/security/certmanager/main_test.go
@@ -58,6 +58,9 @@ func setupCertManagerOperator(t test.TestHelper) {
 	if smcpVer.LessThan(version.SMCP_2_4) {
 		return
 	}
+	if env.GetArch() == "z" || env.GetArch() == "p" {
+		return
+	}
 
 	t.Cleanup(func() {
 		oc.DeleteFromString(t, certManagerNs, rootCA)

--- a/pkg/tests/tasks/security/certmanager/plugin_ca_test.go
+++ b/pkg/tests/tasks/security/certmanager/plugin_ca_test.go
@@ -30,6 +30,9 @@ func TestPluginCaCert(t *testing.T) {
 		if ocpVersion.LessThan(version.OCP_4_12) {
 			t.Skip("istio-csr is not supported in OCP older than v4.12")
 		}
+		if env.GetArch() == "z" || env.GetArch() == "p" {
+			t.Skip("istio-csr is not supported for IBM Z&P")
+		}
 
 		meshValues := map[string]interface{}{
 			"Name":    smcpName,


### PR DESCRIPTION
Skip cert-manager test cases when OCP_ARCH is equal to z or p