### PR TITLE
OSSM-4309 Revert changes to WaitCondition, create WaitForPhase and avoid flaky for not created csv

### DIFF
--- a/pkg/certmanageroperator/install.go
+++ b/pkg/certmanageroperator/install.go
@@ -68,7 +68,7 @@ func waitOperatorSucceded(t test.TestHelper, certManagerOperatorNs string) {
 	// When the operator is installed, the CSV take some time to be created, need to wait until is created to validate the phase
 	retry.UntilSuccess(t, func(t test.TestHelper) {
 		if !certManagerOperatorExists(t) {
-			t.Fatalf("cert-manager-operator is not yet installed")
+			t.Error("cert-manager-operator is not yet installed")
 		}
 	})
 

--- a/pkg/tests/tasks/observability/custom_prometheus_test.go
+++ b/pkg/tests/tasks/observability/custom_prometheus_test.go
@@ -125,7 +125,7 @@ func ocWaitOperatorInstall(t test.TestHelper, ns, subscriptionName string) {
 		"{.status.installPlanRef.kind}", "InstallPlan",
 		"Install plan was created.", "Wait for install plan failed.")
 	installPlanName := ocGetJsonpath(t, ns, "subscription", subscriptionName, "{.status.installPlanRef.name}")
-	oc.WaitFor(t, ns, "installplan", installPlanName, "condition=Installed")
+	oc.WaitCondition(t, ns, "installplan", installPlanName, "Installed")
 }
 
 func installPrometheusOperator(t test.TestHelper, ns string) {

--- a/pkg/tests/tasks/observability/openshift_monitoring_test.go
+++ b/pkg/tests/tasks/observability/openshift_monitoring_test.go
@@ -100,7 +100,7 @@ func TestOpenShiftMonitoring(t *testing.T) {
 		oc.WaitSMCPReady(t, meshNamespace, smcpName)
 
 		t.LogStep("Wait until Kiali is ready")
-		oc.WaitFor(t, meshNamespace, "Kiali", kialiName, "condition=Successful")
+		oc.WaitCondition(t, meshNamespace, "Kiali", kialiName, "Successful")
 
 		t.LogStep("Verify that Kiali was reconciled by Istio Operator")
 		retry.UntilSuccess(t, func(t test.TestHelper) {

--- a/pkg/tests/tasks/traffic/ingress/gatewayapi_test.go
+++ b/pkg/tests/tasks/traffic/ingress/gatewayapi_test.go
@@ -82,7 +82,7 @@ func TestGatewayApi(t *testing.T) {
 			})
 
 			t.LogStep("Wait for Gateway to be ready")
-			oc.WaitFor(t, ns, "Gateway", "gateway", "condition=Ready")
+			oc.WaitCondition(t, ns, "Gateway", "gateway", "Ready")
 
 			t.LogStep("Verfiy the GatewayApi access the httpbin service using curl")
 			retry.UntilSuccess(t, func(t TestHelper) {
@@ -128,7 +128,7 @@ func TestGatewayApi(t *testing.T) {
 			})
 
 			t.LogStep("Wait for Gateway to be ready")
-			oc.WaitFor(t, ns, "Gateway", "gateway", "condition=Ready")
+			oc.WaitCondition(t, ns, "Gateway", "gateway", "Ready")
 
 			t.LogStep("Verify the Gateway-Controller Profile access the httpbin service using curl")
 			retry.UntilSuccess(t, func(t TestHelper) {

--- a/pkg/util/oc/oc.go
+++ b/pkg/util/oc/oc.go
@@ -1,6 +1,8 @@
 package oc
 
 import (
+	"fmt"
+
 	"github.com/maistra/maistra-test-tool/pkg/util/check/common"
 	"github.com/maistra/maistra-test-tool/pkg/util/retry"
 	"github.com/maistra/maistra-test-tool/pkg/util/test"
@@ -192,9 +194,14 @@ func DeletePodNoWait(t test.TestHelper, podLocator PodLocatorFunc) {
 	DefaultOC.DeletePodNoWait(t, podLocator)
 }
 
-func WaitFor(t test.TestHelper, ns string, kind string, name string, forCondition string) {
+func WaitCondition(t test.TestHelper, ns string, kind string, name string, condition string) {
 	t.T().Helper()
-	DefaultOC.WaitFor(t, ns, kind, name, forCondition)
+	DefaultOC.WaitFor(t, ns, kind, name, fmt.Sprintf("condition=%s", condition))
+}
+
+func WaitForPhase(t test.TestHelper, ns string, kind string, name string, phase string) {
+	t.T().Helper()
+	DefaultOC.WaitFor(t, ns, kind, name, fmt.Sprintf("jsonpath='{.status.phase}'=%s", phase))
 }
 
 func WaitSMMRReady(t test.TestHelper, ns string) {

--- a/pkg/util/oc/pod_commands.go
+++ b/pkg/util/oc/pod_commands.go
@@ -98,7 +98,7 @@ func (o OC) WaitPodReadyWithOptions(t test.TestHelper, options retry.RetryOption
 
 func (o OC) WaitDeploymentRolloutComplete(t test.TestHelper, ns string, deploymentNames ...string) {
 	t.T().Helper()
-	timeout := 3 * time.Minute // TODO: make this configurable?
+	timeout := 4 * time.Minute // TODO: make this configurable?
 	start := time.Now()
 	for _, name := range deploymentNames {
 		usedUpTime := time.Now().Sub(start)


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/OSSM-4309


To continue improving the cert-manager test case and avoid flaky on this test I did some changes:

- Revert changes on WaitCondition, the func it's available again
- Create the func WaitForPhase to use in cert-manager test case to wait until csv is Succeed
- WaitFor is now a common func and it's used by WaitCondition and WaitForPhase
- Added a retry and a certManagerOperatorExists before to verify the phase because take around 10 seconds after the creation of the operator to be displayed the csv


Now in the cert-manager setup we will see the entire process of the creation and verification of the operator installation:

```
    install.go:62: STEP 2: Install cert-manager-operator
    install.go:67:    Waiting for cert-manager-operator to succeed
    install.go:71:    FAILURE: cert-manager-operator is not yet installed
    install.go:69:    --- Attempt 1/60 failed. Retrying...
    install.go:71:    FAILURE: cert-manager-operator is not yet installed
    install.go:69:    --- Attempt 2/60 failed. Retrying...
    install.go:71:    FAILURE: cert-manager-operator is not yet installed
    install.go:69:    --- Attempt 3/60 failed. Retrying...
    install.go:71:    FAILURE: cert-manager-operator is not yet installed
    install.go:69:    --- Attempt 4/60 failed. Retrying...
    install.go:69:    --- Attempt 5/60 successful; total time: 7.58s
    install.go:75:    Wait for condition jsonpath='{.status.phase}'=Succeeded on csv cert-manager-operator/cert-manager-operator.v1.11.1...
    install.go:75:    SUCCESS: Condition jsonpath='{.status.phase}'=Succeeded met by csv cert-manager-operator/cert-manager-operator.v1.11.1
    install.go:76:    Pod cert-manager-operator-controller-manager-5bff7d87f-mjsh4 in namespace cert-manager-operator is ready!
    install.go:77:    FAILURE: no pods found using selector app=cert-manager in namespace cert-manager
    install.go:77:    --- Attempt 1/60 failed. Retrying in 4s...
    install.go:77:    FAILURE: no pods found using selector app=cert-manager in namespace cert-manager
    install.go:77:    --- Attempt 2/60 failed. Retrying in 4s...
    install.go:77:    FAILURE: no pods found using selector app=cert-manager in namespace cert-manager
    install.go:77:    --- Attempt 3/60 failed. Retrying in 4s...
    install.go:77:    FAILURE: no pods found using selector app=cert-manager in namespace cert-manager
    install.go:77:    --- Attempt 4/60 failed. Retrying in 4s...
    install.go:77:    Pod cert-manager-5c47b6c74f-8xxt6 in namespace cert-manager is ready!
    install.go:77:    --- Attempt 5/60 successful; total time: 19.84s
    install.go:41:
    install.go:41: STEP 3: Create root ca
```