### PR TITLE
Move uninstall from certmanager test

### DIFF
--- a/pkg/tests/tasks/security/certmanager/istio_csr_test.go
+++ b/pkg/tests/tasks/security/certmanager/istio_csr_test.go
@@ -56,7 +56,6 @@ func TestIstioCsr(t *testing.T) {
 			oc.DeleteSecret(t, meshNamespace, "istiod-tls")
 			oc.DeleteSecret(t, meshNamespace, "istio-ca")
 			oc.RecreateNamespace(t, ns.Foo)
-			certmanageroperator.Uninstall(t)
 		})
 
 		certmanageroperator.InstallIfNotExist(t)

--- a/pkg/tests/tasks/security/certmanager/plugin_ca_test.go
+++ b/pkg/tests/tasks/security/certmanager/plugin_ca_test.go
@@ -50,6 +50,7 @@ func TestPluginCaCert(t *testing.T) {
 			oc.DeleteFromString(t, meshNamespace, cacerts)
 			oc.DeleteSecret(t, meshNamespace, "cacerts")
 			oc.RecreateNamespace(t, ns.Foo)
+			certmanageroperator.Uninstall(t)
 		})
 
 		certmanageroperator.InstallIfNotExist(t)


### PR DESCRIPTION
After executing the full run I need to move the uninstall func for cert-manager to the TestPluginCaCert to avoid uninstalling before to execute all the test cases related to cert-manager