### PR TITLE
OSSM-4195 adding more information to step in failure

### DIFF
--- a/pkg/tests/tasks/observability/custom_prometheus_test.go
+++ b/pkg/tests/tasks/observability/custom_prometheus_test.go
@@ -88,7 +88,7 @@ func TestCustomPrometheus(t *testing.T) {
 				fmt.Sprintf(`istio_requests_total{namespace="%s",container="istio-proxy",source_app="istio-ingressgateway",destination_app="productpage"}`, ns.Bookinfo))
 
 			if len(resp.Data.Result) == 0 {
-				t.Errorf("No data points received from Prometheus API")
+				t.Errorf("No data points received from Prometheus API, status: %s", resp.Status)
 			}
 		})
 	})


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/OSSM-4195

Adding print resp.Status when failure to get in the log more information about what was the failure in the request