### PR TITLE
OSSM-4451 Skip TestOperatorCanUpdatePrometheusConfigMap changes and avoid flakiness

### DIFF
--- a/pkg/tests/ossm/prometheus_scoped_scraping_test.go
+++ b/pkg/tests/ossm/prometheus_scoped_scraping_test.go
@@ -206,7 +206,7 @@ func checkConfigurationReloadingTriggered(t test.TestHelper, start time.Time) {
 			prometheusPodSelector, "config-reloader",
 			assert.OutputContains("Reload triggered",
 				"Triggered configuration reloading",
-				"Expected to trigger configuration reloading, but did not",
+				fmt.Sprintf("Expected to trigger configuration reloading, but did not. Start time: %s", start.String()),
 			),
 		)
 	})

--- a/pkg/tests/ossm/prometheus_scoped_scraping_test.go
+++ b/pkg/tests/ossm/prometheus_scoped_scraping_test.go
@@ -200,7 +200,7 @@ func checkConfigurationReloadingTriggered(t test.TestHelper, start time.Time) {
 	// By default, any changes in the `ConfigMap`, the kubelet will sync them to the mapped volume on one minute interval.
 	t.Log("Wait one minute on the kubelet to update the volume to reflect the changes")
 	time.Sleep(1 * time.Minute)
-	retry.UntilSuccessWithOptions(t, retry.Options().DelayBetweenAttempts(5*time.Second).MaxAttempts(13), func(t test.TestHelper) {
+	retry.UntilSuccessWithOptions(t, retry.Options().DelayBetweenAttempts(5*time.Second).MaxAttempts(15), func(t test.TestHelper) {
 		oc.LogsSince(t,
 			start,
 			prometheusPodSelector, "config-reloader",

--- a/pkg/tests/ossm/prometheus_scoped_scraping_test.go
+++ b/pkg/tests/ossm/prometheus_scoped_scraping_test.go
@@ -11,12 +11,14 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/check/common"
 	"github.com/maistra/maistra-test-tool/pkg/util/check/require"
 	"github.com/maistra/maistra-test-tool/pkg/util/curl"
+	"github.com/maistra/maistra-test-tool/pkg/util/env"
 	namespaces "github.com/maistra/maistra-test-tool/pkg/util/ns"
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
 	"github.com/maistra/maistra-test-tool/pkg/util/pod"
 	"github.com/maistra/maistra-test-tool/pkg/util/retry"
 	"github.com/maistra/maistra-test-tool/pkg/util/shell"
 	"github.com/maistra/maistra-test-tool/pkg/util/test"
+	"github.com/maistra/maistra-test-tool/pkg/util/version"
 )
 
 var prometheusPodSelector oc.PodLocatorFunc = pod.MatchingSelector("app=prometheus,maistra-control-plane=istio-system", meshNamespace)
@@ -24,6 +26,10 @@ var prometheusPodSelector oc.PodLocatorFunc = pod.MatchingSelector("app=promethe
 func TestOperatorCanUpdatePrometheusConfigMap(t *testing.T) {
 	test.NewTest(t).Groups(test.Full).Run(func(t test.TestHelper) {
 		t.Log("This test checks if the operator can update Prometheus ConfigMap when the SMMR is updated")
+
+		if env.GetSMCPVersion().LessThan(version.SMCP_2_4) {
+			t.Skip("Test only valid in SMCP versions v2.4+")
+		}
 
 		t.Cleanup(func() {
 			oc.ApplyString(t, meshNamespace, smmr)

--- a/pkg/util/oc/pod_commands.go
+++ b/pkg/util/oc/pod_commands.go
@@ -61,7 +61,7 @@ func (o OC) LogsSince(t test.TestHelper, start time.Time, podLocator PodLocatorF
 	t.T().Helper()
 	pod := podLocator(t, &o)
 	o.Invoke(t,
-		fmt.Sprintf("kubectl logs -n %s %s -c %s --since=%ds", pod.Namespace, pod.Name, container, int(math.Floor(time.Since(start).Seconds()))),
+		fmt.Sprintf("kubectl logs -n %s %s -c %s --since=%ds", pod.Namespace, pod.Name, container, int(math.Ceil(time.Since(start).Seconds()))),
 		checks...)
 }
 

--- a/pkg/util/oc/pod_commands.go
+++ b/pkg/util/oc/pod_commands.go
@@ -2,6 +2,7 @@ package oc
 
 import (
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -60,7 +61,7 @@ func (o OC) LogsSince(t test.TestHelper, start time.Time, podLocator PodLocatorF
 	t.T().Helper()
 	pod := podLocator(t, &o)
 	o.Invoke(t,
-		fmt.Sprintf("kubectl logs -n %s %s -c %s --since=%ds", pod.Namespace, pod.Name, container, int(time.Since(start).Round(time.Second).Seconds())),
+		fmt.Sprintf("kubectl logs -n %s %s -c %s --since=%ds", pod.Namespace, pod.Name, container, int(math.Floor(time.Since(start).Seconds()))),
 		checks...)
 }
 


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/OSSM-4451

Made these changes:

- Skip test case in versions less than 2.4
- Increase the retry in checkConfigurationReloadingTriggered
- Round up in LogsSince, we can have the case where are rounding down and that can make the test flaky. 