### PR TITLE
OSSM-4472 Fix ior test case in versions less than 2.4

### DIFF
--- a/pkg/tests/ossm/ior_test.go
+++ b/pkg/tests/ossm/ior_test.go
@@ -40,10 +40,6 @@ func TestIOR(t *testing.T) {
 	test.NewTest(t).Groups(test.Full).Run(func(t test.TestHelper) {
 		t.Log("This test verifies the behavior of IOR.")
 
-		if env.GetSMCPVersion().LessThan(version.SMCP_2_4) {
-			t.Skip("This case is only valid for 2.4 or higher SMCP version")
-		}
-
 		meshNamespace := env.GetDefaultMeshNamespace()
 		meshName := env.GetDefaultSMCPName()
 
@@ -56,6 +52,11 @@ func TestIOR(t *testing.T) {
 		createSimpleGateway := func(t test.TestHelper) {
 			t.Logf("Creating Gateway for %s host", host)
 			oc.ApplyString(t, "", generateGateway("gw", meshNamespace, host))
+		}
+
+		deleteSimpleGateway := func(t test.TestHelper) {
+			t.Logf("Deleting Gateway for %s host", host)
+			oc.DeleteFromString(t, "", generateGateway("gw", meshNamespace, host))
 		}
 
 		checkSimpleGateway := func(t test.TestHelper) {
@@ -97,6 +98,7 @@ func TestIOR(t *testing.T) {
 				if env.GetSMCPVersion().GreaterThanOrEqual(version.SMCP_2_5) {
 					removeIORCustomSetting(t, meshNamespace, meshName)
 				}
+				deleteSimpleGateway(t)
 			})
 
 			t.LogStep("Ensure the IOR enabled")

--- a/pkg/tests/ossm/ior_test.go
+++ b/pkg/tests/ossm/ior_test.go
@@ -40,6 +40,10 @@ func TestIOR(t *testing.T) {
 	test.NewTest(t).Groups(test.Full).Run(func(t test.TestHelper) {
 		t.Log("This test verifies the behavior of IOR.")
 
+		if env.GetSMCPVersion().LessThan(version.SMCP_2_4) {
+			t.Skip("This case is only valid for 2.4 or higher SMCP version")
+		}
+
 		meshNamespace := env.GetDefaultMeshNamespace()
 		meshName := env.GetDefaultSMCPName()
 


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/OSSM-4472

it's failing in 2.3 and less because of the non-deletion of the simple gateway route created before, so I fix the cleanup func on subtest case check the basic capabilities of IOR and now is working in 2.3 and less. Tested in both 2.3 and 2.4 version and it's working

```
--- PASS: TestIOR (258.54s)
    --- SKIP: TestIOR/check_IOR_off_by_default_v2.5 (0.00s)
    --- PASS: TestIOR/check_IOR_basic_functionalities (2.58s)
    --- PASS: TestIOR/check_routes_aren't_deleted_during_v2.3_to_v2.4_upgrade (115.86s)
    --- PASS: TestIOR/check_IOR_does_not_delete_routes_after_deleting_Istio_pod (91.50s)
```

```
--- PASS: TestIOR (124.20s)
    --- SKIP: TestIOR/check_IOR_off_by_default_v2.5 (0.00s)
    --- PASS: TestIOR/check_IOR_basic_functionalities (2.46s)
    --- SKIP: TestIOR/check_routes_aren't_deleted_during_v2.3_to_v2.4_upgrade (0.00s)
    --- PASS: TestIOR/check_IOR_does_not_delete_routes_after_deleting_Istio_pod (93.43s)
PASS
ok  	github.com/maistra/maistra-test-tool/pkg/tests/ossm	127.578s
```

