### PR TITLE
OSSM-4601 Delete test from interop run and add retry to delete cert

### DIFF
--- a/pkg/tests/tasks/security/certmanager/istio_csr_test.go
+++ b/pkg/tests/tasks/security/certmanager/istio_csr_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestIstioCsr(t *testing.T) {
-	test.NewTest(t).Id("T38").Groups(test.Full, test.ARM, test.InterOp).Run(func(t test.TestHelper) {
+	test.NewTest(t).Id("T38").Groups(test.Full, test.ARM).Run(func(t test.TestHelper) {
 		//Validate OCP version, this test setup can't be executed in OCP versions less than 4.12
 		//More information in: https://57747--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-security.html#ossm-cert-manager-integration-istio_ossm-security
 		smcpVer := env.GetSMCPVersion()

--- a/pkg/tests/tasks/security/certmanager/plugin_ca_test.go
+++ b/pkg/tests/tasks/security/certmanager/plugin_ca_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestPluginCaCert(t *testing.T) {
-	test.NewTest(t).Id("T41").Groups(test.Full, test.ARM, test.InterOp).Run(func(t test.TestHelper) {
+	test.NewTest(t).Id("T41").Groups(test.Full, test.ARM).Run(func(t test.TestHelper) {
 		//Validate OCP version, this test setup can't be executed in OCP versions less than 4.12
 		//More information in: https://57747--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-security.html#ossm-cert-manager-integration-istio_ossm-security
 		smcpVer := env.GetSMCPVersion()

--- a/pkg/util/oc/oc_struct.go
+++ b/pkg/util/oc/oc_struct.go
@@ -191,7 +191,10 @@ func (o OC) createSecretOrConfigMapFromFiles(t test.TestHelper, ns string, kind 
 		if kind == "secret generic" {
 			k = "secret"
 		}
-		o.DeleteResource(t, ns, k, name)
+		retry.UntilSuccessWithOptions(t, retry.Options().MaxAttempts(5).LogAttempts(false), func(t test.TestHelper) {
+			t.T().Helper()
+			o.DeleteResource(t, ns, k, name)
+		})
 		cmd := fmt.Sprintf(`oc create %s %s -n %s `, kind, name, ns)
 		for _, file := range files {
 			cmd += fmt.Sprintf(" --from-file=%s", file)


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/OSSM-4601

We have some flaky result in interop pipeline, certmanager take a lot of time to come up so we removed certmanager related test cases from interop run and TestTLSOriginationSDS was flaky because in some point the api it's not ready when we delete the certificate after install ngnix, so to mitigate this failure I added a retry in the delete cert command to retry if we got failures in the process