### PR TITLE
Add TestFederatedOpenShiftMonitoring

### DIFF
--- a/pkg/tests/tasks/observability/custom_prometheus_test.go
+++ b/pkg/tests/tasks/observability/custom_prometheus_test.go
@@ -84,7 +84,7 @@ func TestCustomPrometheus(t *testing.T) {
 
 		t.LogStep("Testing if 'istio_requests_total' metric is available through Prometheus API")
 		retry.UntilSuccess(t, func(t test.TestHelper) {
-			resp := prometheus.CustomPrometheus.Query(t, customPrometheusNs,
+			resp := prometheus.CustomPrometheusQuery(t, customPrometheusNs,
 				fmt.Sprintf(`istio_requests_total{namespace="%s",container="istio-proxy",source_app="istio-ingressgateway",destination_app="productpage"}`, ns.Bookinfo))
 
 			if len(resp.Data.Result) == 0 {

--- a/pkg/tests/tasks/observability/federated_openshift_monitoring_test.go
+++ b/pkg/tests/tasks/observability/federated_openshift_monitoring_test.go
@@ -1,0 +1,76 @@
+package observability
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/maistra/maistra-test-tool/pkg/app"
+	"github.com/maistra/maistra-test-tool/pkg/util/check/assert"
+	"github.com/maistra/maistra-test-tool/pkg/util/curl"
+	"github.com/maistra/maistra-test-tool/pkg/util/env"
+	"github.com/maistra/maistra-test-tool/pkg/util/istio"
+	"github.com/maistra/maistra-test-tool/pkg/util/ns"
+	"github.com/maistra/maistra-test-tool/pkg/util/oc"
+	"github.com/maistra/maistra-test-tool/pkg/util/prometheus"
+	"github.com/maistra/maistra-test-tool/pkg/util/retry"
+	"github.com/maistra/maistra-test-tool/pkg/util/test"
+)
+
+// TestFederatedOpenShiftMonitoring requires OpenShift Monitoring stack to be enabled.
+// See the comment on TestOpenShiftMonitoring for help setting up on crc
+func TestFederatedOpenShiftMonitoring(t *testing.T) {
+	test.NewTest(t).Id("federated-openshift-monitoring-integration").Groups(test.Full).Run(func(t test.TestHelper) {
+		meshValues := map[string]string{
+			"Name":    smcpName,
+			"Version": env.GetSMCPVersion().String(),
+			"Member":  ns.Foo,
+		}
+
+		t.Cleanup(func() {
+			oc.DeleteFromTemplate(t, monitoringNs, clusterMonitoringConfigTmpl, map[string]bool{"Enabled": false})
+			oc.RecreateNamespace(t, ns.Foo)
+			oc.RecreateNamespace(t, meshNamespace)
+		})
+
+		t.LogStep("Waiting until user workload monitoring stack is up and running")
+		oc.ApplyTemplate(t, monitoringNs, clusterMonitoringConfigTmpl, map[string]bool{"Enabled": true})
+		oc.WaitPodsExist(t, userWorkloadMonitoringNs)
+		oc.WaitAllPodsReady(t, userWorkloadMonitoringNs)
+
+		t.LogStep("Deploying SMCP")
+		oc.ApplyTemplate(t, meshNamespace, federatedMonitoringMeshTmpl, meshValues)
+		oc.WaitSMCPReady(t, meshNamespace, smcpName)
+
+		t.LogStep("Deploy httpbin")
+		app.InstallAndWaitReady(t, app.Httpbin(ns.Foo))
+		oc.WaitPodsExist(t, ns.Foo)
+		oc.WaitAllPodsReady(t, ns.Foo)
+
+		t.LogStep("Generate some ingress traffic")
+		oc.ApplyFile(t, ns.Foo, "https://raw.githubusercontent.com/maistra/istio/maistra-2.4/samples/httpbin/httpbin-gateway.yaml")
+		httpbinURL := fmt.Sprintf("http://%s/headers", istio.GetIngressGatewayHost(t, meshNamespace))
+		retry.UntilSuccess(t, func(t test.TestHelper) {
+			curl.Request(t, httpbinURL, nil, assert.ResponseStatus(http.StatusOK))
+		})
+
+		t.LogStep("Apply federated metrics monitor")
+		oc.ApplyString(t, meshNamespace, federatedMonitor)
+
+		t.LogStep("Check istiod metrics")
+		retry.UntilSuccess(t, func(t test.TestHelper) {
+			resp := prometheus.ThanosQuery(t, monitoringNs, `pilot_info{mesh_id="unique-mesh-id"}`)
+			if len(resp.Data.Result) == 0 {
+				t.Errorf("No data points received from Prometheus API. Response status: %s", resp.Status)
+			}
+		})
+
+		t.LogStep("Check httpbin metrics")
+		retry.UntilSuccess(t, func(t test.TestHelper) {
+			resp := prometheus.ThanosQuery(t, monitoringNs, `istio_requests_total{mesh_id="unique-mesh-id"}`)
+			if len(resp.Data.Result) == 0 {
+				t.Errorf("No data points received from Prometheus API. Response status: %s", resp.Status)
+			}
+		})
+	})
+}

--- a/pkg/tests/tasks/observability/main_test.go
+++ b/pkg/tests/tasks/observability/main_test.go
@@ -10,8 +10,10 @@ import (
 )
 
 var (
-	smcpName      = env.GetDefaultSMCPName()
-	meshNamespace = env.GetDefaultMeshNamespace()
+	smcpName                 = env.GetDefaultSMCPName()
+	meshNamespace            = env.GetDefaultMeshNamespace()
+	monitoringNs             = "openshift-monitoring"
+	userWorkloadMonitoringNs = "openshift-user-workload-monitoring"
 
 	//go:embed yaml/cluster-monitoring-config.tmpl.yaml
 	clusterMonitoringConfigTmpl string
@@ -25,8 +27,14 @@ var (
 	//go:embed yaml/istio-proxy-monitor.yaml
 	istioProxyMonitor string
 
+	//go:embed yaml/federated-monitor.yaml
+	federatedMonitor string
+
 	//go:embed yaml/mesh.tmpl.yaml
 	meshTmpl string
+
+	//go:embed yaml/federated-monitoring-mesh.tmpl.yaml
+	federatedMonitoringMeshTmpl string
 
 	//go:embed yaml/kiali-user-workload-monitoring.tmpl.yaml
 	kialiUserWorkloadMonitoringTmpl string

--- a/pkg/tests/tasks/observability/openshift_monitoring_test.go
+++ b/pkg/tests/tasks/observability/openshift_monitoring_test.go
@@ -21,11 +21,9 @@ import (
 )
 
 const (
-	kialiName                = "kiali-user-workload-monitoring"
-	monitoringNs             = "openshift-monitoring"
-	userWorkloadMonitoringNs = "openshift-user-workload-monitoring"
-	thanosTokenPrefix        = "prometheus-user-workload-token-"
-	thanosTokenSecret        = "thanos-querier-web-token"
+	kialiName         = "kiali-user-workload-monitoring"
+	thanosTokenPrefix = "prometheus-user-workload-token-"
+	thanosTokenSecret = "thanos-querier-web-token"
 )
 
 // TestOpenShiftMonitoring requires OpenShift Monitoring stack to be enabled.

--- a/pkg/tests/tasks/observability/yaml/federated-monitor.yaml
+++ b/pkg/tests/tasks/observability/yaml/federated-monitor.yaml
@@ -1,0 +1,22 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: istio-federation
+spec:
+  selector:
+    matchLabels:
+      app: prometheus
+  endpoints:
+  - targetPort: 9090
+    path: /federate
+    interval: 30s
+    scrapeTimeout: 30s
+    honorLabels: true
+    params:
+      'match[]':
+        - '{job="kubernetes-pods"}'
+        - '{job="kubernetes-services"}'
+    relabelings:
+    - action: replace
+      replacement: "unique-mesh-id"
+      targetLabel: mesh_id

--- a/pkg/tests/tasks/observability/yaml/federated-monitoring-mesh.tmpl.yaml
+++ b/pkg/tests/tasks/observability/yaml/federated-monitoring-mesh.tmpl.yaml
@@ -1,0 +1,29 @@
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+metadata:
+  name: {{ .Name }}
+spec:
+  addons:
+    grafana:
+      enabled: false
+    kiali:
+      enabled: false
+  gateways:
+    egress:
+      enabled: false
+    openshiftRoute:
+      enabled: false
+  security:
+    dataPlane:
+      mtls: true
+  tracing:
+    type: None
+  version: {{ .Version }}
+---
+apiVersion: maistra.io/v1
+kind: ServiceMeshMemberRoll
+metadata:
+  name: default
+spec:
+  members:
+  - {{ .Member }}

--- a/pkg/util/prometheus/prometheus.go
+++ b/pkg/util/prometheus/prometheus.go
@@ -4,8 +4,14 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/test"
 )
 
-var DefaultPrometheus = NewPrometheus("app=prometheus")
-var CustomPrometheus = NewPrometheus("prometheus=prometheus")
+var DefaultPrometheus = NewPrometheus("app=prometheus", "prometheus")
+
+var DefaultCustomPrometheus = DefaultPrometheus.
+	WithSelector("prometheus=prometheus")
+
+var DefaultThanos = DefaultPrometheus.
+	WithSelector("app.kubernetes.io/instance=thanos-querier").
+	WithContainerName("thanos-query")
 
 type PrometheusResult struct {
 	Metric map[string]string `json:"metric"`
@@ -23,9 +29,19 @@ type PrometheusResponse struct {
 }
 
 type Prometheus interface {
+	WithSelector(selector string) Prometheus
+	WithContainerName(containerName string) Prometheus
 	Query(t test.TestHelper, ns string, query string) PrometheusResponse
 }
 
 func Query(t test.TestHelper, ns string, query string) PrometheusResponse {
 	return DefaultPrometheus.Query(t, ns, query)
+}
+
+func CustomPrometheusQuery(t test.TestHelper, ns string, query string) PrometheusResponse {
+	return DefaultCustomPrometheus.Query(t, ns, query)
+}
+
+func ThanosQuery(t test.TestHelper, ns string, query string) PrometheusResponse {
+	return DefaultThanos.Query(t, ns, query)
 }


### PR DESCRIPTION
Added `TestFederatedOpenShiftMonitoring` in `pkg.tests.tasks.observability` to test support for federating metrics from Service Mesh to OpenShift's monitoring stack.

## Changes

### pkg.tests.tasks.observability

- Added `TestFederatedOpenShiftMonitoring` (in `federated_openshift_monitoring_test.go`).
- Moved a couple monitoring constants from `openshift_monitoring_test.go` to `main.go` as they are used in `TestFederatedOpenShiftMonitoring` as well.

### pkg.util.prometheus

- Added variable `DefaultThanos`, a new default `Prometheus` instance configured for OpenShift monitoring's Thanos.
- Added function `ThanosQuery` to support easy queries to OpenShift monitoring's Thanos instance (proxy for `DefaultThanos.Query`).
- Renamed variable `CustomPrometheus` to `DefaultCustomPrometheus` to be in line with `DefaultThanos` and `DefaultPrometheus`.
- Added function `CustomPrometheusQuery` as proxy for `DefaultCustomPrometheus.Query`.
- Added field `containerName` to `prometheus_struct` to represent Prometheus instances with different container names.
- Modified method `prometheus_struct.Query` to support querying Prometheus instances with different container names.
  - Also factored the parsing of the response out to a separate function for readability.
- Added methods `WithSelector` and `WithContainerName` to `Prometheus` interface to support "inheritance" between `Prometheus` instances (they can use the defaults from a "parent" configuration and only change what they need).
  - This will minimize the impact of adding new members to `prometheus_struct` as only the "root" configurations (currently only `DefaultPrometheus`) need to be updated with defaults.
