### PR TITLE
OSSM-4658 Update files to be able to work with 2.5.x operator version by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ This command runs the entire test suite against the minimum supported `ServiceMe
 
 #### Running against a specific Operator version
 
-By default, maistra-test-tool assumes that the OSSM Operator version is `2.4.0` and runs tests against the `v2.2`, `v2.3`, and `v2.4` version of the ServiceMeshControlPlane.
-To run against the '2.3.x' version of the Operator, run the tests with the `OPERATOR_VERSION` environment variable set to `2.3.x`. For example, for Operator version `2.3.3`, run the tests as follows:
+By default, maistra-test-tool assumes that the OSSM Operator version is `2.5.0` and runs tests against the `v2.3`, `v2.4`, and `v2.5` version of the ServiceMeshControlPlane.
+To run against the '2.4.x' version of the Operator, run the tests with the `OPERATOR_VERSION` environment variable set to `2.4.x`. For example, for Operator version `2.4.2`, run the tests as follows:
 
 ```console
-OPERATOR_VERSION=2.3.3 make test
+OPERATOR_VERSION=2.4.2 make test
 ```
 
 ### Running a group of tests

--- a/pkg/tests/tasks/observability/federated_openshift_monitoring_test.go
+++ b/pkg/tests/tasks/observability/federated_openshift_monitoring_test.go
@@ -48,7 +48,7 @@ func TestFederatedOpenShiftMonitoring(t *testing.T) {
 		oc.WaitAllPodsReady(t, ns.Foo)
 
 		t.LogStep("Generate some ingress traffic")
-		oc.ApplyFile(t, ns.Foo, "https://raw.githubusercontent.com/maistra/istio/maistra-2.4/samples/httpbin/httpbin-gateway.yaml")
+		oc.ApplyFile(t, ns.Foo, "https://raw.githubusercontent.com/maistra/istio/maistra-2.5/samples/httpbin/httpbin-gateway.yaml")
 		httpbinURL := fmt.Sprintf("http://%s/headers", istio.GetIngressGatewayHost(t, meshNamespace))
 		retry.UntilSuccess(t, func(t test.TestHelper) {
 			curl.Request(t, httpbinURL, nil, assert.ResponseStatus(http.StatusOK))

--- a/pkg/tests/tasks/observability/openshift_monitoring_test.go
+++ b/pkg/tests/tasks/observability/openshift_monitoring_test.go
@@ -171,7 +171,7 @@ func waitKialiAndVerifyIsReconciled(t test.TestHelper) {
 
 func generateTrafficAndcheckMetrics(t test.TestHelper, thanosToken string) {
 	t.LogStep("Generate some ingress traffic")
-	oc.ApplyFile(t, ns.Foo, "https://raw.githubusercontent.com/maistra/istio/maistra-2.4/samples/httpbin/httpbin-gateway.yaml")
+	oc.ApplyFile(t, ns.Foo, "https://raw.githubusercontent.com/maistra/istio/maistra-2.5/samples/httpbin/httpbin-gateway.yaml")
 	httpbinURL := fmt.Sprintf("http://%s/headers", istio.GetIngressGatewayHost(t, meshNamespace))
 	retry.UntilSuccess(t, func(t test.TestHelper) {
 		curl.Request(t, httpbinURL, nil, assert.ResponseStatus(http.StatusOK))

--- a/pkg/tests/tasks/security/certmanager/istio_csr_test.go
+++ b/pkg/tests/tasks/security/certmanager/istio_csr_test.go
@@ -112,7 +112,7 @@ func TestIstioCsr(t *testing.T) {
 		})
 
 		t.LogStep("Check mTLS traffic from ingress gateway to httpbin")
-		oc.ApplyFile(t, ns.Foo, "https://raw.githubusercontent.com/maistra/istio/maistra-2.4/samples/httpbin/httpbin-gateway.yaml")
+		oc.ApplyFile(t, ns.Foo, "https://raw.githubusercontent.com/maistra/istio/maistra-2.5/samples/httpbin/httpbin-gateway.yaml")
 		httpbinURL := fmt.Sprintf("http://%s/headers", istio.GetIngressGatewayHost(t, meshNamespace))
 		retry.UntilSuccess(t, func(t test.TestHelper) {
 			curl.Request(t, httpbinURL, nil, assert.ResponseStatus(http.StatusOK))

--- a/pkg/tests/tasks/security/certmanager/plugin_ca_test.go
+++ b/pkg/tests/tasks/security/certmanager/plugin_ca_test.go
@@ -89,7 +89,7 @@ func TestPluginCaCert(t *testing.T) {
 		})
 
 		t.LogStep("Check mTLS traffic from ingress gateway to httpbin")
-		oc.ApplyFile(t, ns.Foo, "https://raw.githubusercontent.com/maistra/istio/maistra-2.4/samples/httpbin/httpbin-gateway.yaml")
+		oc.ApplyFile(t, ns.Foo, "https://raw.githubusercontent.com/maistra/istio/maistra-2.5/samples/httpbin/httpbin-gateway.yaml")
 		httpbinURL := fmt.Sprintf("http://%s/headers", istio.GetIngressGatewayHost(t, meshNamespace))
 		retry.UntilSuccess(t, func(t test.TestHelper) {
 			curl.Request(t, httpbinURL, nil, assert.ResponseStatus(http.StatusOK))

--- a/pkg/util/env/env.go
+++ b/pkg/util/env/env.go
@@ -50,7 +50,7 @@ func GetDefaultMeshNamespace() string {
 }
 
 func GetSMCPVersion() version.Version {
-	return version.ParseVersion(getenv("SMCP_VERSION", "v2.4"))
+	return version.ParseVersion(getenv("SMCP_VERSION", "v2.5"))
 }
 
 func GetArch() string {

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-OPERATOR_VERSION=${OPERATOR_VERSION:-"2.4.0"}
+OPERATOR_VERSION=${OPERATOR_VERSION:-"2.5.0"}
 OPERATOR_VERSION="${OPERATOR_VERSION#v}" # remove "v" prefix if necessary
 
 echo "OSSM Operator version is $OPERATOR_VERSION"
@@ -10,7 +10,8 @@ echo "OSSM Operator version is $OPERATOR_VERSION"
 case "$OPERATOR_VERSION" in
     2.3.*) SUPPORTED_VERSIONS=("v2.1" "v2.2" "v2.3") ;;
     2.4.*) SUPPORTED_VERSIONS=("v2.2" "v2.3" "v2.4") ;;
-    *) echo "ERROR: unknown operator version: $OPERATOR_VERSION; expect either 2.3.x or 2.4.x"; exit 1 ;;
+    2.5.*) SUPPORTED_VERSIONS=("v2.3" "v2.4" "v2.5") ;;
+    *) echo "ERROR: unknown operator version: $OPERATOR_VERSION; expect either 2.3.x, 2.4.x or 2.5.x"; exit 1 ;;
 esac
 
 log() {

--- a/templates/smcp-templates/v2.5/cr_2.5_default_template.yaml
+++ b/templates/smcp-templates/v2.5/cr_2.5_default_template.yaml
@@ -1,0 +1,25 @@
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+metadata:
+  name: {{ .Name }}
+spec:
+  version: v2.5
+  tracing:
+    type: Jaeger
+    sampling: 10000
+  policy:
+    type: Istiod
+  addons:
+    grafana:
+      enabled: true
+    jaeger:
+      install:
+        storage:
+          type: Memory
+    kiali:
+      enabled: true
+    prometheus:
+      enabled: true
+  
+  telemetry:
+    type: Istiod


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/OSSM-4658

Update all the files to work with 2.5 Operator version. Set new default version to 2.5 SMCP and 2.5.x operator version