### PR TITLE
OSSM-4701 Adding the capability to enable or disable must gather after test case failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,14 @@ To run tests on Red Hat Openshift Service on AWS (ROSA), set the `ROSA` environm
 ROSA=true make test
 ```
 
+### Disable must-gather for failed tests cases
+
+To disable must-gather run after each test case failure in the test run, set the `MUST_GATHER` environment variable to `false`. Take into count that if the variable does not exist by default it is set to `true`:
+
+```console
+MUST_GATHER=false make test
+```
+
 ### Running multi-cluster test cases
 
 The test suite contains both single- and multi-cluster test cases. 

--- a/pkg/util/env/env.go
+++ b/pkg/util/env/env.go
@@ -69,7 +69,7 @@ func GetMustGatherTag() string {
 	return getenv("MUST_GATHER_TAG", "2.4")
 }
 
-func MustGatherEnable() bool {
+func IsMustGatherEnabled() bool {
 	return getenv("MUST_GATHER", "true") == "true"
 }
 

--- a/pkg/util/env/env.go
+++ b/pkg/util/env/env.go
@@ -69,6 +69,10 @@ func GetMustGatherTag() string {
 	return getenv("MUST_GATHER_TAG", "2.4")
 }
 
+func MustGatherEnable() bool {
+	return getenv("MUST_GATHER", "true") == "true"
+}
+
 func GetKubeconfig() string {
 	return getenv("KUBECONFIG", "")
 }

--- a/pkg/util/test/subtest.go
+++ b/pkg/util/test/subtest.go
@@ -25,7 +25,7 @@ func (t subTest) Run(f func(t TestHelper)) {
 			t.Log()
 			if th.Failed() {
 				t.Logf("Subtest failed in %.2fs (excluding cleanup)", time.Now().Sub(start).Seconds())
-				if env.MustGatherEnable() {
+				if env.IsMustGatherEnabled() {
 					captureMustGather(t)
 				}
 			} else {

--- a/pkg/util/test/subtest.go
+++ b/pkg/util/test/subtest.go
@@ -3,6 +3,8 @@ package test
 import (
 	"testing"
 	"time"
+
+	"github.com/maistra/maistra-test-tool/pkg/util/env"
 )
 
 type subTest struct {
@@ -23,7 +25,9 @@ func (t subTest) Run(f func(t TestHelper)) {
 			t.Log()
 			if th.Failed() {
 				t.Logf("Subtest failed in %.2fs (excluding cleanup)", time.Now().Sub(start).Seconds())
-				captureMustGather(t)
+				if env.MustGatherEnable() {
+					captureMustGather(t)
+				}
 			} else {
 				t.Logf("Subtest completed in %.2fs (excluding cleanup)", time.Now().Sub(start).Seconds())
 			}

--- a/pkg/util/test/test.go
+++ b/pkg/util/test/test.go
@@ -77,7 +77,9 @@ func (t *topLevelTest) Run(f func(t TestHelper)) {
 		t.t.Log()
 		if th.Failed() {
 			t.t.Logf("Test failed in %.2fs (excluding cleanup)", time.Now().Sub(start).Seconds())
-			captureMustGather(t.t)
+			if env.MustGatherEnable() {
+				captureMustGather(t.t)
+			}
 		} else {
 			t.t.Logf("Test completed in %.2fs (excluding cleanup)", time.Now().Sub(start).Seconds())
 		}

--- a/pkg/util/test/test.go
+++ b/pkg/util/test/test.go
@@ -77,7 +77,7 @@ func (t *topLevelTest) Run(f func(t TestHelper)) {
 		t.t.Log()
 		if th.Failed() {
 			t.t.Logf("Test failed in %.2fs (excluding cleanup)", time.Now().Sub(start).Seconds())
-			if env.MustGatherEnable() {
+			if env.IsMustGatherEnabled() {
 				captureMustGather(t.t)
 			}
 		} else {


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/OSSM-4701

Adding the retrieve of the environmental variable MUST_GATHER to enable or disable must gather collection after test case failures