### PR TITLE
OSSM-5388: Fix 2.5 smoke test

### DIFF
--- a/pkg/tests/ossm/smoke_test.go
+++ b/pkg/tests/ossm/smoke_test.go
@@ -38,6 +38,7 @@ var (
 		&version.SMCP_2_2,
 		&version.SMCP_2_3,
 		&version.SMCP_2_4,
+		&version.SMCP_2_5,
 	}
 )
 


### PR DESCRIPTION
Tested through local and Jenkins with the 2.5 build. It run successfully. 