### PR TITLE
OSSM-5596:Skip Web Assembly IBM P/Z

### DIFF
--- a/pkg/tests/tasks/extensions/threescale_wasm_plugin_test.go
+++ b/pkg/tests/tasks/extensions/threescale_wasm_plugin_test.go
@@ -28,15 +28,16 @@ const (
 
 func TestThreeScaleWasmPlugin(t *testing.T) {
 	test.NewTest(t).Groups(test.Full).Run(func(t test.TestHelper) {
+
+		if env.GetArch() == "z" || env.GetArch() == "p" {
+			t.Skip("Web Assembly is not supported for IBM Z&P")
+		}
+
 		t.Cleanup(func() {
 			oc.RecreateNamespace(t, ns.Foo)
 			oc.RecreateNamespace(t, meshNamespace)
 			oc.DeleteNamespace(t, threeScaleNs)
 		})
-
-		if env.GetArch() == "z" || env.GetArch() == "p" {
-			t.Skip("Web Assembly is not supported for IBM Z&P")
-		}
 
 		t.LogStep("Deploy SMCP")
 		oc.ApplyTemplate(t, meshNamespace, meshTmpl, map[string]string{


### PR DESCRIPTION

 Web Assembly IBM P/Z is not supported for the IBM P/Z platform.
 
         Error from server (NotFound): namespaces "3scale" not found

reformatted the code to skip the test case properly.

