### PR TITLE
[OSSM-5611] Workaround for cleaning instability on OCP in PSI

### DIFF
--- a/pkg/tests/ossm-federation/federation_failover_test.go
+++ b/pkg/tests/ossm-federation/federation_failover_test.go
@@ -68,9 +68,9 @@ func TestMultiClusterFederationFailover(t *testing.T) {
 				region:            eastRegion,
 				zone:              eastZone,
 			},
-			controlPlaneInstaller: func(t TestHelper, ft federationTest) {
-				installSMCPandSMMR(t, ft.west, ft.testdataPath+"/west-mesh/smcp.yaml", ft.testdataPath+"/west-mesh/smmr.yaml")
-				installSMCPandSMMR(t, ft.east, ft.testdataPath+"/east-mesh/smcp.yaml", ft.testdataPath+"/east-mesh/smmr.yaml")
+			controlPlaneInstaller: func(t TestHelper, ft federationTest, ingressServiceType string) {
+				installSMCPandSMMR(t, ft.west, ft.testdataPath+"/west-mesh/smcp.yaml", ft.testdataPath+"/west-mesh/smmr.yaml", ingressServiceType)
+				installSMCPandSMMR(t, ft.east, ft.testdataPath+"/east-mesh/smcp.yaml", ft.testdataPath+"/east-mesh/smmr.yaml", ingressServiceType)
 			},
 			bookinfoInstaller: func(t TestHelper, ft federationTest) {
 				t.LogStep("Install bookinfo in west-mesh")

--- a/pkg/tests/ossm-federation/federation_traffic_splitting_test.go
+++ b/pkg/tests/ossm-federation/federation_traffic_splitting_test.go
@@ -52,9 +52,9 @@ func TestFederation(t *testing.T) {
 				smcpNamespace:     "east-mesh-system",
 				bookinfoNamespace: "east-mesh-bookinfo",
 			},
-			controlPlaneInstaller: func(t TestHelper, ft federationTest) {
-				installSMCPandSMMR(t, ft.west, ft.testdataPath+"/west-mesh/smcp.yaml", ft.testdataPath+"/west-mesh/smmr.yaml")
-				installSMCPandSMMR(t, ft.east, ft.testdataPath+"/east-mesh/smcp.yaml", ft.testdataPath+"/east-mesh/smmr.yaml")
+			controlPlaneInstaller: func(t TestHelper, ft federationTest, ingressServiceType string) {
+				installSMCPandSMMR(t, ft.west, ft.testdataPath+"/west-mesh/smcp.yaml", ft.testdataPath+"/west-mesh/smmr.yaml", ingressServiceType)
+				installSMCPandSMMR(t, ft.east, ft.testdataPath+"/east-mesh/smcp.yaml", ft.testdataPath+"/east-mesh/smmr.yaml", ingressServiceType)
 			},
 			bookinfoInstaller: defaultBookinfoInstaller,
 			checker:           defaultChecker,
@@ -80,7 +80,7 @@ func TestFederationDifferentCerts(t *testing.T) {
 				smcpNamespace:     "east-mesh-system",
 				bookinfoNamespace: "east-mesh-bookinfo",
 			},
-			controlPlaneInstaller: func(t TestHelper, ft federationTest) {
+			controlPlaneInstaller: func(t TestHelper, ft federationTest, ingressServiceType string) {
 				t.Log("Create Secret 'cacerts' for custom CA certs in west-mesh")
 				ft.west.oc.CreateGenericSecretFromFiles(t, ft.west.smcpNamespace, "cacerts",
 					"testdata/cacerts/ca-cert.pem",
@@ -88,8 +88,8 @@ func TestFederationDifferentCerts(t *testing.T) {
 					"testdata/cacerts/root-cert.pem",
 					"testdata/cacerts/cert-chain.pem")
 
-				installSMCPandSMMR(t, ft.west, ft.testdataPath+"/west-mesh/smcp_custom_cert.yaml", ft.testdataPath+"/west-mesh/smmr.yaml")
-				installSMCPandSMMR(t, ft.east, ft.testdataPath+"/east-mesh/smcp.yaml", ft.testdataPath+"/east-mesh/smmr.yaml")
+				installSMCPandSMMR(t, ft.west, ft.testdataPath+"/west-mesh/smcp_custom_cert.yaml", ft.testdataPath+"/west-mesh/smmr.yaml", ingressServiceType)
+				installSMCPandSMMR(t, ft.east, ft.testdataPath+"/east-mesh/smcp.yaml", ft.testdataPath+"/east-mesh/smmr.yaml", ingressServiceType)
 			},
 			bookinfoInstaller: defaultBookinfoInstaller,
 			checker:           defaultChecker,

--- a/pkg/tests/ossm-federation/testdata/failover/east-mesh/smcp.yaml
+++ b/pkg/tests/ossm-federation/testdata/failover/east-mesh/smcp.yaml
@@ -61,7 +61,7 @@ spec:
         enabled: true
         routerMode: sni-dnat
         service:
-          type: LoadBalancer
+          type: {{ .IngressServiceType }}
           metadata:
             labels:
               # to prevent west-mesh-ingress's service from including default ingress pods

--- a/pkg/tests/ossm-federation/testdata/failover/west-mesh/smcp.yaml
+++ b/pkg/tests/ossm-federation/testdata/failover/west-mesh/smcp.yaml
@@ -61,7 +61,7 @@ spec:
         enabled: true
         routerMode: sni-dnat
         service:
-          type: LoadBalancer
+          type: {{ .IngressServiceType }}
           metadata:
             labels:
               # to prevent east-mesh-ingress's service from including default ingress pods

--- a/pkg/tests/ossm-federation/testdata/traffic-splitting/east-mesh/smcp.yaml
+++ b/pkg/tests/ossm-federation/testdata/traffic-splitting/east-mesh/smcp.yaml
@@ -61,7 +61,7 @@ spec:
         enabled: true
         routerMode: sni-dnat
         service:
-          type: LoadBalancer
+          type: {{ .IngressServiceType }}
           metadata:
             labels:
               # to prevent west-mesh-ingress's service from including default ingress pods

--- a/pkg/tests/ossm-federation/testdata/traffic-splitting/west-mesh/smcp.yaml
+++ b/pkg/tests/ossm-federation/testdata/traffic-splitting/west-mesh/smcp.yaml
@@ -65,7 +65,7 @@ spec:
         enabled: true
         routerMode: sni-dnat
         service:
-          type: LoadBalancer
+          type: {{ .IngressServiceType }}
           metadata:
             labels:
               # to prevent east-mesh-ingress's service from including default ingress pods

--- a/pkg/tests/ossm-federation/testdata/traffic-splitting/west-mesh/smcp_custom_cert.yaml
+++ b/pkg/tests/ossm-federation/testdata/traffic-splitting/west-mesh/smcp_custom_cert.yaml
@@ -61,7 +61,7 @@ spec:
         enabled: true
         routerMode: sni-dnat
         service:
-          type: LoadBalancer
+          type: {{ .IngressServiceType }}
           metadata:
             labels:
               # to prevent east-mesh-ingress's service from including default ingress pods


### PR DESCRIPTION
ref: https://issues.redhat.com/browse/OSSM-5611
info: https://redhat-internal.slack.com/archives/C04KW747ZLK/p1704453981200879