### PR TITLE
[OSSM-3903] Improve log step and log in current test cases

### DIFF
--- a/pkg/tests/tasks/security/authorization/tcp_test.go
+++ b/pkg/tests/tasks/security/authorization/tcp_test.go
@@ -36,7 +36,7 @@ func TestAuthorizationTCPTraffic(t *testing.T) {
 		})
 
 		t.Log("This test validates authorization policies for TCP traffic.")
-		t.Log("Doc reference: https://istio.io/v1.14/docs/tasks/security/authorization/authz-tcp/")
+		t.Log("Doc reference: https://istio.io/latest/docs/tasks/security/authorization/authz-tcp/")
 
 		ossm.DeployControlPlane(t)
 
@@ -56,6 +56,7 @@ func TestAuthorizationTCPTraffic(t *testing.T) {
 			t.LogStep("Apply an invalid policy to allow requests to port 9000 and add an HTTP GET field")
 			oc.ApplyString(t, ns, TCPAllowGETPolicy)
 
+			t.LogStep("Check whether the requests to port 9000 and 9001 are denied")
 			retry.UntilSuccess(t, func(t test.TestHelper) {
 				assertPortTcpEchoDenied(t, ns, "9000")
 				assertPortTcpEchoDenied(t, ns, "9001")
@@ -69,6 +70,7 @@ func TestAuthorizationTCPTraffic(t *testing.T) {
 			t.LogStep("Apply a policy to deny tcp requests to port 9000")
 			oc.ApplyString(t, ns, TCPDenyGETPolicy)
 
+			t.LogStep("Check whether the request to port 9000 is denied and request to port 9001 is accepted")
 			retry.UntilSuccess(t, func(t test.TestHelper) {
 				assertPortTcpEchoDenied(t, ns, "9000")
 				assertPortTcpEchoAccepted(t, ns, "9001")
@@ -82,6 +84,7 @@ func TestAuthorizationTCPTraffic(t *testing.T) {
 			t.LogStep("Apply a policy to allow tcp requests to port 9000 and 9001")
 			oc.ApplyString(t, ns, TCPAllowPolicy)
 
+			t.LogStep("Check whether the requests to port 9000 and 9001 are accepted")
 			retry.UntilSuccess(t, func(t test.TestHelper) {
 				assertPortTcpEchoAccepted(t, ns, "9000")
 				assertPortTcpEchoAccepted(t, ns, "9001")

--- a/pkg/tests/tasks/traffic/ingress/secure_gateways_test.go
+++ b/pkg/tests/tasks/traffic/ingress/secure_gateways_test.go
@@ -50,6 +50,9 @@ func TestSecureGateways(t *testing.T) {
 	NewTest(t).Id("T9").Groups(Full, InterOp, ARM).Run(func(t TestHelper) {
 		ns := "bookinfo"
 
+		t.Log("This test verifies secure gateways.")
+		t.Log("Doc reference: https://istio.io/latest/docs/tasks/traffic-management/ingress/secure-ingress/")
+
 		t.Cleanup(func() {
 			oc.DeleteSecret(t, meshNamespace, "httpbin-credential")
 			oc.DeleteSecret(t, meshNamespace, "helloworld-credential")
@@ -80,6 +83,7 @@ func TestSecureGateways(t *testing.T) {
 				createRouteWithTLS(t, meshNamespace, "httpbin.example.com", "https", "istio-ingressgateway", "passthrough")
 			}
 
+			t.LogStep("check if httpbin responds with teapot")
 			retry.UntilSuccess(t, func(t TestHelper) {
 				curl.Request(t,
 					teapotURL,

--- a/pkg/util/oc/oc_struct.go
+++ b/pkg/util/oc/oc_struct.go
@@ -148,6 +148,7 @@ func (o OC) ApplyFile(t test.TestHelper, ns string, file string) {
 
 func (o OC) DeleteFromString(t test.TestHelper, ns string, yamls ...string) {
 	t.T().Helper()
+	t.Logf("Deleting resources from namespace %s", ns)
 	o.withKubeconfig(t, func() {
 		t.T().Helper()
 		shell.ExecuteWithInput(t, fmt.Sprintf("oc %s delete -f - --ignore-not-found", nsFlag(ns)), concatenateYamls(yamls...))
@@ -156,6 +157,7 @@ func (o OC) DeleteFromString(t test.TestHelper, ns string, yamls ...string) {
 
 func (o OC) DeleteFile(t test.TestHelper, ns string, file string) {
 	t.T().Helper()
+	t.Logf("Deleting file %s from namespace %s", file, ns)
 	o.withKubeconfig(t, func() {
 		t.T().Helper()
 		shell.Executef(t, "kubectl delete %s -f %s --ignore-not-found", nsFlag(ns), file)


### PR DESCRIPTION
 I have changed logic in one test: [code](https://github.com/maistra/maistra-test-tool/compare/main...unsortedhashsets:maistra-test-tool:OSSM-3903?expand=1#diff-cbdd641c277eec8e5fd7bd89cf0bc42a0485ec443082b708e1cb1e9072d5e325R111)

From my point of view if we just want to check that the connection failed we can use the existing function `assertConnectionFailure` but for expanded test the reason can be only to check the zeroes curl placeholder in response :thinking: 

Issue: https://issues.redhat.com/browse/OSSM-3903