### PR TITLE
 OSSM-5819: Update the curl image tag

### DIFF
--- a/pkg/tests/ossm/initcontainer_test.go
+++ b/pkg/tests/ossm/initcontainer_test.go
@@ -75,13 +75,13 @@ spec:
 
       initContainers:
       - name: init
-        image: curlimages/curl
+        image: curlimages/curl:8.4.0
         command: ["/bin/echo", "[init worked]"]
         imagePullPolicy: IfNotPresent
 
       containers:
       - name: sleep
-        image: curlimages/curl
+        image: curlimages/curl:8.4.0
         command: ["/bin/sleep", "3650d"]
         imagePullPolicy: IfNotPresent`
 )


### PR DESCRIPTION
https://hub.docker.com/r/curlimages/curl/tags

s390x platform is not available in the latest tag.

Created the curl issue: https://github.com/curl/curl-container/issues/46#issuecomment-1869611737 for the IBM-Z platform, it affects one test case in the Maistra-test-tool. 

once it is resolve, we can update back to latest. 

This test case fails in the IBM-Z platform. 