### PR TITLE
update cert manager version

### DIFF
--- a/pkg/certmanageroperator/install.go
+++ b/pkg/certmanageroperator/install.go
@@ -20,7 +20,7 @@ var (
 
 	certManagerOperatorNs = "cert-manager-operator"
 	certManagerNs         = "cert-manager"
-	certmanagerVersion    = "cert-manager-operator.v1.12.1"
+	certmanagerVersion    = "cert-manager-operator.v1.13.0"
 )
 
 func InstallIfNotExist(t test.TestHelper) {


### PR DESCRIPTION
![Screenshot from 2024-01-26 14-43-34](https://github.com/maistra/maistra-test-tool/assets/55099523/488d0d4f-579c-4990-973d-a42a80abad9a)



The cert-Manager operator version is updated to 1.13.0