### PR TITLE
OSSM-5446: fix IOR test case for 2.5 & ARM

### DIFF
--- a/pkg/tests/ossm/ior_test.go
+++ b/pkg/tests/ossm/ior_test.go
@@ -37,7 +37,7 @@ const (
 
 // TestIOR tests IOR error regarding routes recreated: https://issues.redhat.com/browse/OSSM-1974. IOR will be deprecated on 2.4 and willl be removed on 3.0
 func TestIOR(t *testing.T) {
-	test.NewTest(t).Groups(test.Full).Run(func(t test.TestHelper) {
+	test.NewTest(t).Groups(test.Full, test.ARM).Run(func(t test.TestHelper) {
 		t.Log("This test verifies the behavior of IOR.")
 
 		meshNamespace := env.GetDefaultMeshNamespace()

--- a/pkg/tests/ossm/ior_test.go
+++ b/pkg/tests/ossm/ior_test.go
@@ -84,7 +84,7 @@ func TestIOR(t *testing.T) {
 			t.LogStep("Check whether the IOR has the correct default setting")
 			if env.GetSMCPVersion().GreaterThanOrEqual(version.SMCP_2_5) {
 				if getIORSetting(t, meshNamespace, meshName) != "true" {
-					t.Fatal("Expect to find IOR disabled by default in v2.4+,but it is currently enabled")
+					t.Fatal("Expect to find IOR enabled by default in v2.4+,but it is currently disabled")
 				} else {
 					t.LogSuccess("Got the expected true for IOR setting")
 				}

--- a/pkg/tests/ossm/ior_test.go
+++ b/pkg/tests/ossm/ior_test.go
@@ -80,16 +80,12 @@ func TestIOR(t *testing.T) {
 		t.NewSubTest("check IOR on by default v2.5").Run(func(t test.TestHelper) {
 			if env.GetSMCPVersion().LessThan(version.SMCP_2_5) {
 				t.Skip("Skipping until 2.5")
-			}
-			t.LogStep("Check whether the IOR has the correct default setting")
-			if env.GetSMCPVersion().GreaterThanOrEqual(version.SMCP_2_5) {
+			} else {
 				if getIORSetting(t, meshNamespace, meshName) != "true" {
 					t.Fatal("Expect to find IOR enabled by default in v2.5+, but it is currently disabled")
 				} else {
 					t.LogSuccess("Got the expected true for IOR setting")
 				}
-			} else {
-				t.Skip("IOR is not set by default versions less than v2.3")
 			}
 		})
 

--- a/pkg/tests/ossm/ior_test.go
+++ b/pkg/tests/ossm/ior_test.go
@@ -77,14 +77,14 @@ func TestIOR(t *testing.T) {
 
 		DeployControlPlane(t)
 
-		t.NewSubTest("check IOR off by default v2.5").Run(func(t test.TestHelper) {
+		t.NewSubTest("check IOR on by default v2.5").Run(func(t test.TestHelper) {
 			if env.GetSMCPVersion().LessThan(version.SMCP_2_5) {
 				t.Skip("Skipping until 2.5")
 			}
 			t.LogStep("Check whether the IOR has the correct default setting")
 			if env.GetSMCPVersion().GreaterThanOrEqual(version.SMCP_2_5) {
 				if getIORSetting(t, meshNamespace, meshName) != "true" {
-					t.Fatal("Expect to find IOR disabled by default in v2.4+, but it is currently enabled")
+					t.Fatal("Expect to find IOR disabled by default in v2.4+,but it is currently enabled")
 				} else {
 					t.LogSuccess("Got the expected true for IOR setting")
 				}

--- a/pkg/tests/ossm/ior_test.go
+++ b/pkg/tests/ossm/ior_test.go
@@ -83,10 +83,10 @@ func TestIOR(t *testing.T) {
 			}
 			t.LogStep("Check whether the IOR has the correct default setting")
 			if env.GetSMCPVersion().GreaterThanOrEqual(version.SMCP_2_5) {
-				if getIORSetting(t, meshNamespace, meshName) != "false" {
+				if getIORSetting(t, meshNamespace, meshName) != "true" {
 					t.Fatal("Expect to find IOR disabled by default in v2.4+, but it is currently enabled")
 				} else {
-					t.LogSuccess("Got the expected false for IOR setting")
+					t.LogSuccess("Got the expected true for IOR setting")
 				}
 			} else {
 				t.Skip("IOR is not set by default versions less than v2.3")

--- a/pkg/tests/ossm/ior_test.go
+++ b/pkg/tests/ossm/ior_test.go
@@ -84,7 +84,7 @@ func TestIOR(t *testing.T) {
 			t.LogStep("Check whether the IOR has the correct default setting")
 			if env.GetSMCPVersion().GreaterThanOrEqual(version.SMCP_2_5) {
 				if getIORSetting(t, meshNamespace, meshName) != "true" {
-					t.Fatal("Expect to find IOR enabled by default in v2.4+,but it is currently disabled")
+					t.Fatal("Expect to find IOR enabled by default in v2.5+, but it is currently disabled")
 				} else {
 					t.LogSuccess("Got the expected true for IOR setting")
 				}


### PR DESCRIPTION
`oc -n istio-system get smcp/basic -o jsonpath='{.status.appliedValues.istio.gateways.istio-ingressgateway.ior_enabled}' = true`


In the 2.5, it is set to be the "true"