### PR TITLE
Fix invalid token in openshift_monitoring_test

### DIFF
--- a/pkg/tests/tasks/observability/openshift_monitoring_test.go
+++ b/pkg/tests/tasks/observability/openshift_monitoring_test.go
@@ -59,6 +59,8 @@ func TestOpenShiftMonitoring(t *testing.T) {
 
 		t.LogStep("Deploying Kiali")
 		oc.ApplyTemplate(t, meshNamespace, kialiUserWorkloadMonitoringTmpl, kialiValues)
+		oc.WaitPodRunning(t, pod.MatchingSelector("app=kiali", meshNamespace))
+		kialiPodName := shell.Executef(t, "oc get pod -l app=kiali -n %s -o jsonpath='{.items[0].metadata.name}'", meshNamespace)
 
 		t.LogStep("Grant cluster-monitoring-view to Kiali")
 		oc.ApplyTemplate(t, meshNamespace, kialiClusterMonitoringView, kialiValues)
@@ -77,6 +79,9 @@ func TestOpenShiftMonitoring(t *testing.T) {
 			oc.WaitSMCPReady(t, meshNamespace, smcpName)
 
 			waitKialiAndVerifyIsReconciled(t)
+			t.LogStep("Wait until the old Kiali pod has been deleted")
+			oc.WaitUntilResourceExist(t, meshNamespace, "pod", kialiPodName)
+			kialiPodName = shell.Executef(t, "oc get pod -l app=kiali -n %s -o jsonpath='{.items[0].metadata.name}'", meshNamespace)
 
 			t.LogStep("Fetch Kiali token")
 			kialiToken := fetchKialiToken(t)
@@ -112,6 +117,9 @@ func TestOpenShiftMonitoring(t *testing.T) {
 			oc.WaitSMCPReady(t, meshNamespace, smcpName)
 
 			waitKialiAndVerifyIsReconciled(t)
+			t.LogStep("Wait until the old Kiali pod has been deleted")
+			oc.WaitUntilResourceExist(t, meshNamespace, "pod", kialiPodName)
+			kialiPodName = shell.Executef(t, "oc get pod -l app=kiali -n %s -o jsonpath='{.items[0].metadata.name}'", meshNamespace)
 
 			t.LogStep("Fetch Kiali token")
 			kialiToken := fetchKialiToken(t)

--- a/pkg/util/oc/oc.go
+++ b/pkg/util/oc/oc.go
@@ -271,3 +271,8 @@ func GetProxy(t test.TestHelper) *Proxy {
 	t.T().Helper()
 	return DefaultOC.GetProxy(t)
 }
+
+func WaitUntilResourceExist(t test.TestHelper, ns string, kind string, name string) {
+	t.T().Helper()
+	DefaultOC.WaitUntilResourceExist(t, ns, kind, name)
+}


### PR DESCRIPTION
The test is waiting till kiali CR is reconciled by Istio, but is not waiting till a new Kiali pod is running (and the old one is deleted).
Therefore, it fetches the Kiali token from the older Kiali pod and that is why a query to the thanos fails on `Unauthorized`