### PR TITLE
Fix tls error message check on FIPS cluster

### DIFF
--- a/pkg/tests/tasks/traffic/ingress/secure_gateways_test.go
+++ b/pkg/tests/tasks/traffic/ingress/secure_gateways_test.go
@@ -139,8 +139,10 @@ func TestSecureGateways(t *testing.T) {
 					assert.RequestFails(
 						"request failed as expected",
 						"expected request to fail because no client certificate was provided"),
-					assert.RequestFailsWithErrorMessage(
-						"Get \"https://httpbin.example.com:443/status/418\": remote error: tls: certificate require",
+					assert.RequestFailsWithAnyErrorMessages(
+						[]string{
+							"Get \"https://httpbin.example.com:443/status/418\": remote error: tls: certificate require",
+							"Get \"https://httpbin.example.com:443/status/418\": remote error: tls: handshake failure"}, //FIPS OCP
 						"request failed with expected error message",
 						"request failed but with different error message"))
 			})
@@ -178,8 +180,11 @@ func TestSecureGateways(t *testing.T) {
 					assert.RequestFails(
 						"request failed as expected",
 						"expected request to fail because no client certificate was provided"),
-					assert.RequestFailsWithErrorMessage(
-						"Get \"https://httpbin.example.com:443/status/418\": remote error: tls: certificate require",
+					assert.RequestFailsWithAnyErrorMessages(
+						// FIPS OCP has different message
+						[]string{
+							"Get \"https://httpbin.example.com:443/status/418\": remote error: tls: certificate require",
+							"Get \"https://httpbin.example.com:443/status/418\": remote error: tls: handshake failure"}, //FIPS OCP
 						"request failed with expected error message",
 						"request failed but with different error message"))
 			})

--- a/pkg/util/check/assert/http_response.go
+++ b/pkg/util/check/assert/http_response.go
@@ -61,6 +61,13 @@ func RequestFails(successMsg, failureMsg string) curl.HTTPResponseCheckFunc {
 func RequestFailsWithErrorMessage(expectedErrorMessage, successMsg, failureMsg string) curl.HTTPResponseCheckFunc {
 	return func(t test.TestHelper, resp *http.Response, responseBody []byte, responseErr error, duration time.Duration) {
 		t.T().Helper()
-		common.CheckRequestFailureMessage(t, responseErr, expectedErrorMessage, successMsg, failureMsg, assertFailure)
+		common.CheckRequestFailureMessagesAny(t, responseErr, []string{expectedErrorMessage}, successMsg, failureMsg, assertFailure)
+	}
+}
+
+func RequestFailsWithAnyErrorMessages(expectedErrorMessages []string, successMsg string, failureMsg string) curl.HTTPResponseCheckFunc {
+	return func(t test.TestHelper, resp *http.Response, responseBody []byte, responseErr error, duration time.Duration) {
+		t.T().Helper()
+		common.CheckRequestFailureMessagesAny(t, responseErr, expectedErrorMessages, successMsg, failureMsg, assertFailure)
 	}
 }

--- a/pkg/util/check/common/http_response.go
+++ b/pkg/util/check/common/http_response.go
@@ -138,18 +138,22 @@ func CheckRequestFails(t test.TestHelper, resp *http.Response, responseBody []by
 	}
 }
 
-func CheckRequestFailureMessage(t test.TestHelper, requestError error, expectedErrorMessage string, successMsg, failureMsg string, failure FailureFunc) {
+func CheckRequestFailureMessagesAny(t test.TestHelper, requestError error, expectedErrorMessages []string, successMsg, failureMsg string, failure FailureFunc) {
 	t.T().Helper()
 	if requestError == nil {
 		failure(t, "expected request error, but it is nil", "")
-	} else if strings.Contains(requestError.Error(), expectedErrorMessage) {
-		if successMsg != "" {
-			logSuccess(t, successMsg)
-		}
-	} else {
-		detailMsg := fmt.Sprintf("\nexpected error message:'%s'\nactual error message:'%s'", expectedErrorMessage, requestError.Error())
-		failure(t, failureMsg, detailMsg)
 	}
+	for _, str := range expectedErrorMessages {
+		if strings.Contains(requestError.Error(), str) {
+			if successMsg != "" {
+				logSuccess(t, successMsg)
+			}
+			return
+		}
+	}
+	// none of the expected strings were found
+	detailMsg := fmt.Sprintf("\nexpected any of error messages:'%s'\nactual error message:'%s'", expectedErrorMessages, requestError.Error())
+	failure(t, failureMsg, detailMsg)
 }
 
 func requireNonNilResponse(t test.TestHelper, resp *http.Response) {


### PR DESCRIPTION
Curl Against regular cluster, it fails with msg `certificate required`
```
* processing: https://httpbin.example.com:/status/418
* Added httpbin.example.com:443:10.0.191.52 to DNS cache
* Hostname httpbin.example.com was found in DNS cache
*   Trying 10.0.191.52:443...
* Connected to httpbin.example.com (10.0.191.52) port 443
* ALPN: offers h2,http/1.1
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
*  CAfile: ./sampleCerts/httpbin.example.com/example.com.crt
*  CApath: none
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.3 (IN), TLS handshake, Request CERT (13):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.3 (OUT), TLS handshake, Certificate (11):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=httpbin.example.com; O=httpbin organization
*  start date: Feb  6 13:06:10 2024 GMT
*  expire date: Feb  3 13:06:10 2034 GMT
*  subjectAltName: host "httpbin.example.com" matched cert's "httpbin.example.com"
*  issuer: O=example Inc.; CN=*.example.com
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: httpbin.example.com]
* h2 [:path: /status/418]
* h2 [user-agent: curl/8.2.1]
* h2 [accept: */*]
* Using Stream ID: 1
> GET /status/418 HTTP/2
> Host:httpbin.example.com
> User-Agent: curl/8.2.1
> Accept: */*
> 
* TLSv1.3 (IN), TLS alert, unknown (628):
* OpenSSL SSL_read: OpenSSL/3.1.1: error:0A00045C:SSL routines::tlsv13 alert certificate required, errno 0
* Failed receiving HTTP2 data: 56(Failure when receiving data from the peer)
* Connection #0 to host httpbin.example.com left intact
curl: (56) OpenSSL SSL_read: OpenSSL/3.1.1: error:0A00045C:SSL routines::tlsv13 alert certificate required, errno 0
```

Against FIPS enabled cluster, it fails earlier and only with msg `handshake failure`
```
* processing: https://httpbin.example.com:443/status/418
* Added httpbin.example.com:443:40.116.97.187 to DNS cache
* Hostname httpbin.example.com was found in DNS cache
*   Trying 40.116.97.187:443...
* Connected to httpbin.example.com (40.116.97.187) port 443
* ALPN: offers h2,http/1.1
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
*  CAfile: ./sampleCerts/httpbin.example.com/example.com.crt
*  CApath: none
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
* TLSv1.2 (IN), TLS handshake, Request CERT (13):
* TLSv1.2 (IN), TLS handshake, Server finished (14):
* TLSv1.2 (OUT), TLS handshake, Certificate (11):
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (OUT), TLS handshake, Finished (20):
* TLSv1.2 (IN), TLS alert, handshake failure (552):
* OpenSSL/3.1.1: error:0A000410:SSL routines::sslv3 alert handshake failure
* Closing connection
curl: (35) OpenSSL/3.1.1: error:0A000410:SSL routines::sslv3 alert handshake failure
```