### PR TITLE
Fix nil when request fails without response body

### DIFF
--- a/pkg/util/check/common/http_response.go
+++ b/pkg/util/check/common/http_response.go
@@ -142,6 +142,7 @@ func CheckRequestFailureMessagesAny(t test.TestHelper, requestError error, expec
 	t.T().Helper()
 	if requestError == nil {
 		failure(t, "expected request error, but it is nil", "")
+		return
 	}
 	for _, str := range expectedErrorMessages {
 		if strings.Contains(requestError.Error(), str) {


### PR DESCRIPTION
I forgot to add `return` if a request error is null during changing `CheckRequestFailureMessagesAny` function here https://github.com/maistra/maistra-test-tool/pull/669