### PR TITLE
MTT: Moved Nginx image to quay.io

### DIFF
--- a/pkg/app/yaml/nginx.yaml
+++ b/pkg/app/yaml/nginx.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
       - name: my-nginx
-        image: docker.io/nginx
+        image: quay.io/maistra/nginx
         ports:
         - containerPort: 8443
         volumeMounts:


### PR DESCRIPTION
Docker images are not supported by the IBM-Z platform team, test cases depend on the Nginx those test cases are failing. 