### PR TITLE
[OSSM-6572] MTT: Refactor test pkg imports

### DIFF
--- a/pkg/tests/non-dependant/bug_multiple_smcp_test.go
+++ b/pkg/tests/non-dependant/bug_multiple_smcp_test.go
@@ -10,11 +10,11 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
 	"github.com/maistra/maistra-test-tool/pkg/util/pod"
 	"github.com/maistra/maistra-test-tool/pkg/util/retry"
-	. "github.com/maistra/maistra-test-tool/pkg/util/test"
+	"github.com/maistra/maistra-test-tool/pkg/util/test"
 )
 
 func TestSMCPMultiple(t *testing.T) {
-	NewTest(t).Id("T36").Groups(Full, ARM).Run(func(t TestHelper) {
+	test.NewTest(t).Id("T36").Groups(test.Full, test.ARM).Run(func(t test.TestHelper) {
 		t.Log("This test verifies whether the operator only reconciles one SMCP when two exist in a namespace")
 		t.Log("See https://issues.redhat.com/browse/OSSM-2419")
 
@@ -32,7 +32,7 @@ func TestSMCPMultiple(t *testing.T) {
 			oc.WaitPodReady(t, pod.MatchingSelector("name=istio-operator", env.GetOperatorNamespace()))
 
 			t.LogStep("Check whether ValidatingWebhookConfiguration exists")
-			retry.UntilSuccess(t, func(t TestHelper) {
+			retry.UntilSuccess(t, func(t test.TestHelper) {
 				oc.Get(t, "", "validatingwebhookconfiguration", "openshift-operators.servicemesh-resources.maistra.io")
 				t.LogSuccess("ValidatingWebhookConfiguration was recreated by the operator")
 			})
@@ -55,7 +55,7 @@ func TestSMCPMultiple(t *testing.T) {
 		ossm.InstallSMCPCustom(t, meshNamespace, smcp2)
 
 		t.LogStep("Check whether the second SMCP shows ErrMultipleSMCPs")
-		retry.UntilSuccess(t, func(t TestHelper) {
+		retry.UntilSuccess(t, func(t test.TestHelper) {
 			oc.Get(t, meshNamespace,
 				"smcp", smcp2.Name,
 				assert.OutputContains("ErrMultipleSMCPs",

--- a/pkg/tests/ossm/bug_istiopods_test.go
+++ b/pkg/tests/ossm/bug_istiopods_test.go
@@ -26,11 +26,11 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/pod"
 	"github.com/maistra/maistra-test-tool/pkg/util/retry"
 	"github.com/maistra/maistra-test-tool/pkg/util/template"
-	. "github.com/maistra/maistra-test-tool/pkg/util/test"
+	"github.com/maistra/maistra-test-tool/pkg/util/test"
 )
 
 func TestIstiodPodFailsAfterRestarts(t *testing.T) {
-	NewTest(t).Id("T35").Groups(Full, Disconnected, ARM).Run(func(t TestHelper) {
+	test.NewTest(t).Id("T35").Groups(test.Full, test.Disconnected, test.ARM).Run(func(t test.TestHelper) {
 		t.Log("Verify that Istio pod not get stuck with probes failure after restart")
 		t.Log("Reference: https://issues.redhat.com/browse/OSSM-2434")
 		namespaces := util.GenerateStrings("test-", 50)
@@ -57,7 +57,7 @@ func TestIstiodPodFailsAfterRestarts(t *testing.T) {
 }
 
 func TestIstiodPodFailsWithValidationMessages(t *testing.T) {
-	NewTest(t).Groups(Full, Disconnected, ARM).Run(func(t TestHelper) {
+	test.NewTest(t).Groups(test.Full, test.Disconnected, test.ARM).Run(func(t test.TestHelper) {
 		t.Log("Verify that Istio pod is not failing when validationMessages was enabled")
 
 		oc.RecreateNamespace(t, meshNamespace)
@@ -68,7 +68,7 @@ func TestIstiodPodFailsWithValidationMessages(t *testing.T) {
 
 		istiodPod := pod.MatchingSelector("app=istiod", meshNamespace)
 		oc.WaitPodRunning(t, istiodPod)
-		retry.UntilSuccessWithOptions(t, retry.Options().MaxAttempts(10), func(t TestHelper) {
+		retry.UntilSuccessWithOptions(t, retry.Options().MaxAttempts(10), func(t test.TestHelper) {
 			oc.LogsFromPods(t, meshNamespace, "app=istiod", assert.OutputContains(
 				"successfully acquired lease istio-system/istio-analyze-leader",
 				"Successfully acquired lease for analyzer in istiod pod",

--- a/pkg/tests/ossm/discovery_selectors_test.go
+++ b/pkg/tests/ossm/discovery_selectors_test.go
@@ -25,12 +25,12 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
 	"github.com/maistra/maistra-test-tool/pkg/util/pod"
 	"github.com/maistra/maistra-test-tool/pkg/util/template"
-	. "github.com/maistra/maistra-test-tool/pkg/util/test"
+	"github.com/maistra/maistra-test-tool/pkg/util/test"
 	"github.com/maistra/maistra-test-tool/pkg/util/version"
 )
 
 func TestDiscoverySelectors(t *testing.T) {
-	NewTest(t).Groups(Full, ARM).Run(func(t TestHelper) {
+	test.NewTest(t).Groups(test.Full, test.ARM).Run(func(t test.TestHelper) {
 		t.Log("This test checks if discoverySelectors are being honored")
 		t.Log("See https://issues.redhat.com/browse/OSSM-3802")
 		t.Log("Test case is based on https://istio.io/latest/blog/2021/discovery-selectors/")

--- a/pkg/tests/ossm/initcontainer_test.go
+++ b/pkg/tests/ossm/initcontainer_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/check/assert"
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
 	"github.com/maistra/maistra-test-tool/pkg/util/pod"
-	. "github.com/maistra/maistra-test-tool/pkg/util/test"
+	"github.com/maistra/maistra-test-tool/pkg/util/test"
 )
 
 func TestInitContainerNotRemovedDuringInjection(t *testing.T) {
@@ -28,7 +28,7 @@ func TestInitContainerNotRemovedDuringInjection(t *testing.T) {
 	const goldString = "[init worked]"
 	const podSelector = "app=sleep-init"
 
-	NewTest(t).Id("T33").Groups(Full, ARM).Run(func(t TestHelper) {
+	test.NewTest(t).Id("T33").Groups(test.Full, test.ARM).Run(func(t test.TestHelper) {
 		t.Log("Checking init container not removed during sidecar injection.")
 
 		t.Cleanup(func() {

--- a/pkg/tests/ossm/prometheus_scoped_scraping_test.go
+++ b/pkg/tests/ossm/prometheus_scoped_scraping_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/check/require"
 	"github.com/maistra/maistra-test-tool/pkg/util/curl"
 	"github.com/maistra/maistra-test-tool/pkg/util/env"
-	namespaces "github.com/maistra/maistra-test-tool/pkg/util/ns"
+	"github.com/maistra/maistra-test-tool/pkg/util/ns"
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
 	"github.com/maistra/maistra-test-tool/pkg/util/pod"
 	"github.com/maistra/maistra-test-tool/pkg/util/retry"
@@ -168,10 +168,10 @@ func TestOperatorCanUpdatePrometheusConfigMap(t *testing.T) {
 			oc.DeleteFromString(t, meshNamespace, smmr)
 
 			testPrometheusConfigWithAsserts(t,
-				assertConfigMapDoesNotContainNamespace(namespaces.Bar),
-				assertConfigMapDoesNotContainNamespace(namespaces.Bookinfo),
-				assertConfigMapDoesNotContainNamespace(namespaces.Foo),
-				assertConfigMapDoesNotContainNamespace(namespaces.Legacy),
+				assertConfigMapDoesNotContainNamespace(ns.Bar),
+				assertConfigMapDoesNotContainNamespace(ns.Bookinfo),
+				assertConfigMapDoesNotContainNamespace(ns.Foo),
+				assertConfigMapDoesNotContainNamespace(ns.Legacy),
 			)
 			checkConfigurationReloadingTriggered(t, start)
 			checkPermissionError(t)

--- a/pkg/tests/ossm/ratelimit_test.go
+++ b/pkg/tests/ossm/ratelimit_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/retry"
 	"github.com/maistra/maistra-test-tool/pkg/util/shell"
 	"github.com/maistra/maistra-test-tool/pkg/util/test"
-	. "github.com/maistra/maistra-test-tool/pkg/util/test"
 	"github.com/maistra/maistra-test-tool/pkg/util/version"
 )
 
@@ -40,7 +39,7 @@ var (
 )
 
 func TestRateLimiting(t *testing.T) {
-	NewTest(t).Id("T28").Groups(Full, ARM).MaxVersion(version.SMCP_2_2).Run(func(t TestHelper) {
+	test.NewTest(t).Id("T28").Groups(test.Full, test.ARM).MaxVersion(version.SMCP_2_2).Run(func(t test.TestHelper) {
 		ns := "bookinfo"
 		nsRedis := "redis"
 

--- a/pkg/tests/ossm/route_prevent_additional_ingress_test.go
+++ b/pkg/tests/ossm/route_prevent_additional_ingress_test.go
@@ -8,12 +8,12 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
 	"github.com/maistra/maistra-test-tool/pkg/util/retry"
 	"github.com/maistra/maistra-test-tool/pkg/util/shell"
-	. "github.com/maistra/maistra-test-tool/pkg/util/test"
+	"github.com/maistra/maistra-test-tool/pkg/util/test"
 	"github.com/maistra/maistra-test-tool/pkg/util/version"
 )
 
 func TestRoutePreventAdditionalIngress(t *testing.T) {
-	NewTest(t).Id("T48").Groups(Full, ARM).MaxVersion(version.SMCP_2_5).Run(func(t TestHelper) {
+	test.NewTest(t).Id("T48").Groups(test.Full, test.ARM).MaxVersion(version.SMCP_2_5).Run(func(t test.TestHelper) {
 
 		ER := "extra-routes"
 
@@ -36,7 +36,7 @@ func TestRoutePreventAdditionalIngress(t *testing.T) {
 				"Ingress Route is not created",
 				"Ingress Route is created"))
 
-		t.NewSubTest("additional ingress gateway route creation").Run(func(t TestHelper) {
+		t.NewSubTest("additional ingress gateway route creation").Run(func(t test.TestHelper) {
 			t.Log("Verify that route for additional ingress was created")
 			t.Log("Reference: https://issues.redhat.com/browse/OSSM-3909")
 
@@ -54,7 +54,7 @@ func TestRoutePreventAdditionalIngress(t *testing.T) {
 			oc.WaitSMCPReady(t, ER2, "basic")
 
 			t.LogStep("Verify that Route for additional ingress was created")
-			retry.UntilSuccess(t, func(t TestHelper) {
+			retry.UntilSuccess(t, func(t test.TestHelper) {
 				oc.Get(t,
 					ER2,
 					"route", "igw",

--- a/pkg/tests/ossm/smcp_addons_test.go
+++ b/pkg/tests/ossm/smcp_addons_test.go
@@ -21,13 +21,13 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/check/assert"
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
 	"github.com/maistra/maistra-test-tool/pkg/util/shell"
-	. "github.com/maistra/maistra-test-tool/pkg/util/test"
+	"github.com/maistra/maistra-test-tool/pkg/util/test"
 )
 
 func TestSMCPAddons(t *testing.T) {
-	NewTest(t).Id("T34").Groups(Full, Disconnected, ARM).Run(func(t TestHelper) {
+	test.NewTest(t).Id("T34").Groups(test.Full, test.Disconnected, test.ARM).Run(func(t test.TestHelper) {
 		// Created a subtest because we need to add more test related to Addons in the future.
-		t.NewSubTest("3scale_addon").Run(func(t TestHelper) {
+		t.NewSubTest("3scale_addon").Run(func(t test.TestHelper) {
 			t.LogStep("Enable 3scale in a SMCP expecting to get validation error.")
 			t.Cleanup(func() {
 				shell.Execute(t, fmt.Sprintf(`oc patch -n %s smcp/%s --type merge -p '{"spec":{"addons":{"3scale":{"enabled":false}}}}' || true`, meshNamespace, smcpName))

--- a/pkg/tests/ossm/smcp_must_gather_test.go
+++ b/pkg/tests/ossm/smcp_must_gather_test.go
@@ -28,11 +28,10 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
 	"github.com/maistra/maistra-test-tool/pkg/util/shell"
 	"github.com/maistra/maistra-test-tool/pkg/util/test"
-	. "github.com/maistra/maistra-test-tool/pkg/util/test"
 )
 
 func TestMustGather(t *testing.T) {
-	NewTest(t).Id("T30").Groups(Full, ARM).Run(func(t TestHelper) {
+	test.NewTest(t).Id("T30").Groups(test.Full, test.ARM).Run(func(t test.TestHelper) {
 		t.Log("This test verifies must-gather log collection")
 
 		ns := "bookinfo"
@@ -79,7 +78,7 @@ func TestMustGather(t *testing.T) {
 			}
 		})
 
-		t.NewSubTest("version file").Run(func(t TestHelper) {
+		t.NewSubTest("version file").Run(func(t test.TestHelper) {
 			t.LogStep("verify file version exists")
 			assertFilesExist(t, dir,
 				"**/version")
@@ -94,7 +93,7 @@ func TestMustGather(t *testing.T) {
 					"Expected must gather version was not found"))
 		})
 
-		t.NewSubTest("resources cluster scoped").Run(func(t TestHelper) {
+		t.NewSubTest("resources cluster scoped").Run(func(t test.TestHelper) {
 			t.LogStep("Get nodes of the cluster")
 			nodeOutput := shell.Execute(t, "oc get nodes | awk 'NR>1 { print $1 }'")
 			nodeSlice := strings.Split(nodeOutput, "\n")
@@ -116,7 +115,7 @@ func TestMustGather(t *testing.T) {
 				"**/cluster-scoped-resources/rbac.authorization.k8s.io/clusterroles/istiod-clusterrole-basic-istio-system.yaml")
 		})
 
-		t.NewSubTest("resource for namespaces exist").Run(func(t TestHelper) {
+		t.NewSubTest("resource for namespaces exist").Run(func(t test.TestHelper) {
 			t.LogStep("verify that resources for namespaces are created including bookinfo and istio-system folders")
 			assertFilesExist(t,
 				dir,
@@ -127,7 +126,7 @@ func TestMustGather(t *testing.T) {
 				"**/namespaces/*/rbac.authorization.k8s.io/rolebindings/mesh-users.yaml")
 		})
 
-		t.NewSubTest("cluster service version files validation").Run(func(t TestHelper) {
+		t.NewSubTest("cluster service version files validation").Run(func(t test.TestHelper) {
 			t.LogStep("Get service current service version from the cluster")
 			csvList := shell.Execute(t, "oc get csv -n openshift-operators | awk 'NR>1 { print $1 }'")
 
@@ -144,7 +143,7 @@ func TestMustGather(t *testing.T) {
 	})
 }
 
-func assertFilesExist(t TestHelper, dir string, files ...string) {
+func assertFilesExist(t test.TestHelper, dir string, files ...string) {
 	for _, file := range files {
 		filePath := filepath.Join(dir, file)
 		pathSplit := strings.Split(filePath, "/")

--- a/pkg/tests/ossm/smcp_secret_test.go
+++ b/pkg/tests/ossm/smcp_secret_test.go
@@ -21,14 +21,14 @@ import (
 
 	"github.com/maistra/maistra-test-tool/pkg/util/env"
 	"github.com/maistra/maistra-test-tool/pkg/util/shell"
-	. "github.com/maistra/maistra-test-tool/pkg/util/test"
+	"github.com/maistra/maistra-test-tool/pkg/util/test"
 	"github.com/maistra/maistra-test-tool/pkg/util/version"
 )
 
 func TestSMCPSecret(t *testing.T) {
-	NewTest(t).Id("T52").Groups(Full, Disconnected, ARM).Run(func(t TestHelper) {
+	test.NewTest(t).Id("T52").Groups(test.Full, test.Disconnected, test.ARM).Run(func(t test.TestHelper) {
 		// Created a subtest because we need to add more test related to Addons in the future.
-		t.NewSubTest("secret_validation").Run(func(t TestHelper) {
+		t.NewSubTest("secret_validation").Run(func(t test.TestHelper) {
 
 			if env.GetSMCPVersion().LessThan(version.SMCP_2_4) {
 				t.Skip("Secret is not valid in SMCP versions v2.3")

--- a/pkg/tests/ossm/smcp_tls_ssl_test.go
+++ b/pkg/tests/ossm/smcp_tls_ssl_test.go
@@ -17,11 +17,11 @@ import (
 	"testing"
 
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
-	. "github.com/maistra/maistra-test-tool/pkg/util/test"
+	"github.com/maistra/maistra-test-tool/pkg/util/test"
 )
 
 func TestTLSVersionSMCP(t *testing.T) {
-	NewTest(t).Id("T26").Groups(Full, ARM, InterOp, Disconnected).Run(func(t TestHelper) {
+	test.NewTest(t).Id("T26").Groups(test.Full, test.ARM, test.InterOp, test.Disconnected).Run(func(t test.TestHelper) {
 		t.Log("This test checks if the SMCP updated the tls.minProtocolVersion to TLSv1_0, TLSv1_1, and tls.maxProtocolVersion to TLSv1_3.")
 		t.Cleanup(func() {
 			oc.Patch(t, meshNamespace,
@@ -33,19 +33,19 @@ func TestTLSVersionSMCP(t *testing.T) {
 
 		DeployControlPlane(t) // TODO: remove this and create the SMCP without the patch in each subtest
 
-		t.NewSubTest("minVersion_TLSv1_0").Run(func(t TestHelper) {
+		t.NewSubTest("minVersion_TLSv1_0").Run(func(t test.TestHelper) {
 			t.LogStep("Update SMCP spec.security.controlPlane.tls.minProtocolVersion: TLSv1_0")
 			oc.Patch(t, meshNamespace, "smcp", smcpName, "merge", `{"spec":{"security":{"controlPlane":{"tls":{"minProtocolVersion":"TLSv1_0"}}}}}`)
 			oc.WaitSMCPReady(t, meshNamespace, smcpName)
 		})
 
-		t.NewSubTest("minVersion_TLSv1_1").Run(func(t TestHelper) {
+		t.NewSubTest("minVersion_TLSv1_1").Run(func(t test.TestHelper) {
 			t.LogStep("Check to see if the SMCP minProtocolVersion is TLSv1_1")
 			oc.Patch(t, meshNamespace, "smcp", smcpName, "merge", `{"spec":{"security":{"controlPlane":{"tls":{"minProtocolVersion":"TLSv1_1"}}}}}`)
 			oc.WaitSMCPReady(t, meshNamespace, smcpName)
 		})
 
-		t.NewSubTest("maxVersion_TLSv1_3").Run(func(t TestHelper) {
+		t.NewSubTest("maxVersion_TLSv1_3").Run(func(t test.TestHelper) {
 			t.LogStep("Check to see if the SMCP maxProtocolVersion is TLSv1_3")
 			oc.Patch(t, meshNamespace, "smcp", smcpName, "merge", `{"spec":{"security":{"controlPlane":{"tls":{"maxProtocolVersion":"TLSv1_3"}}}}}`)
 			oc.WaitSMCPReady(t, meshNamespace, smcpName)

--- a/pkg/tests/ossm/smm_test.go
+++ b/pkg/tests/ossm/smm_test.go
@@ -11,11 +11,10 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/retry"
 	"github.com/maistra/maistra-test-tool/pkg/util/shell"
 	"github.com/maistra/maistra-test-tool/pkg/util/test"
-	. "github.com/maistra/maistra-test-tool/pkg/util/test"
 )
 
 func TestSMMRAutoCreationAndDeletion(t *testing.T) {
-	NewTest(t).Id("T39").Groups(Full, Disconnected, ARM).Run(func(t TestHelper) {
+	test.NewTest(t).Id("T39").Groups(test.Full, test.Disconnected, test.ARM).Run(func(t test.TestHelper) {
 		t.Log("This test verifies what happens to the SMMR when SMM is created and deleted")
 		foo := "foo"
 		bar := "bar"
@@ -31,7 +30,7 @@ func TestSMMRAutoCreationAndDeletion(t *testing.T) {
 		t.LogStep("Create two namespaces")
 		oc.CreateNamespace(t, foo, bar)
 
-		t.NewSubTest("create first SMM").Run(func(t TestHelper) {
+		t.NewSubTest("create first SMM").Run(func(t test.TestHelper) {
 			t.Log("This test checks if the SMMR is created when you create a ServiceMeshMember")
 
 			t.LogStep("Create ServiceMeshMembers in namespaces foo and bar")
@@ -50,7 +49,7 @@ func TestSMMRAutoCreationAndDeletion(t *testing.T) {
 			})
 		})
 
-		t.NewSubTest("delete non-terminal SMM").Run(func(t TestHelper) {
+		t.NewSubTest("delete non-terminal SMM").Run(func(t test.TestHelper) {
 			t.Log("This test verifies that the SMMR isn't deleted when one SMM is deleted, but other SMMs still exist")
 			t.Log("See https://issues.redhat.com/browse/OSSM-2374 (implementation)")
 			t.Log("See https://issues.redhat.com/browse/OSSM-3450 (test)")
@@ -64,7 +63,7 @@ func TestSMMRAutoCreationAndDeletion(t *testing.T) {
 			})
 		})
 
-		t.NewSubTest("delete terminal SMM").Run(func(t TestHelper) {
+		t.NewSubTest("delete terminal SMM").Run(func(t test.TestHelper) {
 			t.Log("This test verifies tht the SMMR is deleted when the last SMM is deleted")
 			t.Log("See https://issues.redhat.com/browse/OSSM-2374 (implementation)")
 			t.Log("See https://issues.redhat.com/browse/OSSM-3450 (test)")
@@ -86,7 +85,7 @@ func TestSMMRAutoCreationAndDeletion(t *testing.T) {
 }
 
 func TestSMMReconciliation(t *testing.T) {
-	NewTest(t).Groups(Full, Disconnected, ARM).Run(func(t TestHelper) {
+	test.NewTest(t).Groups(test.Full, test.Disconnected, test.ARM).Run(func(t test.TestHelper) {
 		t.Log("This test verifies whether the member-of label is added back to the namespace")
 		t.Log("See https://issues.redhat.com/browse/OSSM-1397")
 

--- a/pkg/tests/ossm/testssl_test.go
+++ b/pkg/tests/ossm/testssl_test.go
@@ -23,11 +23,11 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
 	"github.com/maistra/maistra-test-tool/pkg/util/pod"
 	"github.com/maistra/maistra-test-tool/pkg/util/retry"
-	. "github.com/maistra/maistra-test-tool/pkg/util/test"
+	"github.com/maistra/maistra-test-tool/pkg/util/test"
 )
 
 func TestSSL(t *testing.T) {
-	NewTest(t).Id("T27").Groups(Full, InterOp, ARM).Run(func(t TestHelper) {
+	test.NewTest(t).Id("T27").Groups(test.Full, test.InterOp, test.ARM).Run(func(t test.TestHelper) {
 		ns := "bookinfo"
 		t.Cleanup(func() {
 			oc.Patch(t, meshNamespace, "smcp", smcpName, "json", `[{"op": "remove", "path": "/spec/security/controlPlane/tls"}]`)
@@ -74,7 +74,7 @@ spec:
 		if env.GetArch() == "arm64" {
 			command = "./testssl.sh -P -6 productpage:9080 || true"
 		}
-		retry.UntilSuccessWithOptions(t, retry.Options().MaxAttempts(10), func(t TestHelper) {
+		retry.UntilSuccessWithOptions(t, retry.Options().MaxAttempts(10), func(t test.TestHelper) {
 			oc.Exec(t,
 				pod.MatchingSelector("app=testssl", ns),
 				"testssl",

--- a/pkg/tests/tasks/extensions/threescale_wasm_plugin_test.go
+++ b/pkg/tests/tasks/extensions/threescale_wasm_plugin_test.go
@@ -157,5 +157,3 @@ func TestThreeScaleWasmPlugin(t *testing.T) {
 		}
 	})
 }
-
-//fmt.Sprintf(`curl http://httpbin:8000/headers -H "Authorization: Bearer %s" -s -o /dev/null -w "%%{http_code}"`, token),

--- a/pkg/tests/tasks/security/authorization/trust_domain_test.go
+++ b/pkg/tests/tasks/security/authorization/trust_domain_test.go
@@ -22,12 +22,12 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/tests/ossm"
 	"github.com/maistra/maistra-test-tool/pkg/util/env"
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
-	. "github.com/maistra/maistra-test-tool/pkg/util/test"
+	"github.com/maistra/maistra-test-tool/pkg/util/test"
 	"github.com/maistra/maistra-test-tool/pkg/util/version"
 )
 
 func TestTrustDomainMigration(t *testing.T) {
-	NewTest(t).Id("T24").Groups(Full, InterOp, ARM).Run(func(t TestHelper) {
+	test.NewTest(t).Id("T24").Groups(test.Full, test.InterOp, test.ARM).Run(func(t test.TestHelper) {
 		foo := "foo"
 		bar := "bar"
 		httpbinUrl := "http://httpbin.foo:8000/ip"
@@ -59,13 +59,13 @@ func TestTrustDomainMigration(t *testing.T) {
 		t.LogStep("Apply trust domain policy to foo namespace")
 		oc.ApplyString(t, foo, TrustDomainPolicy)
 
-		t.NewSubTest("Case 1: Verifying policy works").Run(func(t TestHelper) {
+		t.NewSubTest("Case 1: Verifying policy works").Run(func(t test.TestHelper) {
 			t.LogStep("Check whether requests to foo namespace return 403 to foo namespace and 200 to bar namespace")
 			app.AssertSleepPodRequestForbidden(t, foo, httpbinUrl)
 			app.AssertSleepPodRequestSuccess(t, bar, httpbinUrl)
 		})
 
-		t.NewSubTest("Case 2: Migrate trust domain without trust domain aliases").Run(func(t TestHelper) {
+		t.NewSubTest("Case 2: Migrate trust domain without trust domain aliases").Run(func(t test.TestHelper) {
 			t.LogStep("Apply new-td trust domain")
 			applyTrustDomain(t, "new-td", "", true)
 			oc.RestartAllPodsAndWaitReady(t, foo, bar)
@@ -75,7 +75,7 @@ func TestTrustDomainMigration(t *testing.T) {
 			app.AssertSleepPodRequestForbidden(t, bar, httpbinUrl)
 		})
 
-		t.NewSubTest("Case 3: Migrate trust domain with trust domain aliases").Run(func(t TestHelper) {
+		t.NewSubTest("Case 3: Migrate trust domain with trust domain aliases").Run(func(t test.TestHelper) {
 			t.LogStep("Apply new-td trust domain with alias old-td")
 			applyTrustDomain(t, "new-td", "old-td", true)
 			oc.RestartAllPodsAndWaitReady(t, foo, bar)
@@ -87,7 +87,7 @@ func TestTrustDomainMigration(t *testing.T) {
 	})
 }
 
-func applyTrustDomain(t TestHelper, domain, alias string, mtls bool) {
+func applyTrustDomain(t test.TestHelper, domain, alias string, mtls bool) {
 	t.Logf("Configure spec.security.trust.domain to %q and alias %q", domain, alias)
 
 	if alias != "" {

--- a/pkg/tests/tasks/traffic/circuit_breaking_test.go
+++ b/pkg/tests/tasks/traffic/circuit_breaking_test.go
@@ -30,12 +30,10 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/pod"
 	"github.com/maistra/maistra-test-tool/pkg/util/retry"
 	"github.com/maistra/maistra-test-tool/pkg/util/test"
-
-	. "github.com/maistra/maistra-test-tool/pkg/util/test"
 )
 
 func TestCircuitBreaking(t *testing.T) {
-	NewTest(t).Id("T6").Groups(Full, InterOp, ARM).Run(func(t TestHelper) {
+	test.NewTest(t).Id("T6").Groups(test.Full, test.InterOp, test.ARM).Run(func(t test.TestHelper) {
 		t.Log("This test checks whether the circuit breaker functions correctly. Check documentation: https://istio.io/latest/docs/tasks/traffic-management/circuit-breaking/")
 
 		t.Cleanup(func() {

--- a/pkg/tests/tasks/traffic/common.go
+++ b/pkg/tests/tasks/traffic/common.go
@@ -8,11 +8,10 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
 	"github.com/maistra/maistra-test-tool/pkg/util/pod"
 	"github.com/maistra/maistra-test-tool/pkg/util/template"
-
-	. "github.com/maistra/maistra-test-tool/pkg/util/test"
+	"github.com/maistra/maistra-test-tool/pkg/util/test"
 )
 
-func TestreviewV1(t TestHelper, file string) string {
+func TestreviewV1(t test.TestHelper, file string) string {
 
 	ns := "bookinfo"
 
@@ -30,7 +29,7 @@ func TestreviewV1(t TestHelper, file string) string {
 
 }
 
-func TestreviewV2(t TestHelper, file string) string {
+func TestreviewV2(t test.TestHelper, file string) string {
 
 	ns := "bookinfo"
 
@@ -46,7 +45,7 @@ func TestreviewV2(t TestHelper, file string) string {
 
 }
 
-func TestreviewV3(t TestHelper, file string) string {
+func TestreviewV3(t test.TestHelper, file string) string {
 
 	ns := "bookinfo"
 

--- a/pkg/tests/tasks/traffic/egress/egress_gateways_test.go
+++ b/pkg/tests/tasks/traffic/egress/egress_gateways_test.go
@@ -21,11 +21,11 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/tests/ossm"
 	"github.com/maistra/maistra-test-tool/pkg/util/ns"
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
-	. "github.com/maistra/maistra-test-tool/pkg/util/test"
+	"github.com/maistra/maistra-test-tool/pkg/util/test"
 )
 
 func TestEgressGateways(t *testing.T) {
-	NewTest(t).Id("T13").Groups(Full, InterOp, ARM).Run(func(t TestHelper) {
+	test.NewTest(t).Id("T13").Groups(test.Full, test.InterOp, test.ARM).Run(func(t test.TestHelper) {
 		t.Cleanup(func() {
 			oc.RecreateNamespace(t, ns.Bookinfo)
 		})
@@ -35,7 +35,7 @@ func TestEgressGateways(t *testing.T) {
 		t.LogStep("Install sleep pod")
 		app.InstallAndWaitReady(t, app.Sleep(ns.Bookinfo))
 
-		t.NewSubTest("HTTP").Run(func(t TestHelper) {
+		t.NewSubTest("HTTP").Run(func(t test.TestHelper) {
 			t.LogStepf("Install external httpbin")
 			httpbin := app.HttpbinNoSidecar(ns.MeshExternal)
 			app.InstallAndWaitReady(t, httpbin)
@@ -55,7 +55,7 @@ func TestEgressGateways(t *testing.T) {
 			app.AssertSleepPodRequestSuccess(t, ns.Bookinfo, "http://httpbin.mesh-external:8000/headers")
 		})
 
-		t.NewSubTest("HTTPS").Run(func(t TestHelper) {
+		t.NewSubTest("HTTPS").Run(func(t test.TestHelper) {
 			t.LogStep("Install external nginx")
 			app.InstallAndWaitReady(t, app.NginxExternalTLS(ns.MeshExternal))
 

--- a/pkg/tests/tasks/traffic/egress/egress_gateways_tls_file_mount_test.go
+++ b/pkg/tests/tasks/traffic/egress/egress_gateways_tls_file_mount_test.go
@@ -25,11 +25,11 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/ns"
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
 	"github.com/maistra/maistra-test-tool/pkg/util/pod"
-	. "github.com/maistra/maistra-test-tool/pkg/util/test"
+	"github.com/maistra/maistra-test-tool/pkg/util/test"
 )
 
 func TestTLSOrigination(t *testing.T) {
-	NewTest(t).Id("T14").Groups(Full, InterOp, ARM).Run(func(t TestHelper) {
+	test.NewTest(t).Id("T14").Groups(test.Full, test.InterOp, test.ARM).Run(func(t test.TestHelper) {
 		t.Log("This test verifies that TLS origination works in 2 scenarios:")
 		t.Log("  1) Egress gateway TLS Origination")
 		t.Log("  2) MTLS Origination with file mount (certificates mounted in egress gateway pod)")
@@ -43,7 +43,7 @@ func TestTLSOrigination(t *testing.T) {
 		t.LogStep("Install sleep pod")
 		app.InstallAndWaitReady(t, app.Sleep(ns.Bookinfo))
 
-		t.NewSubTest("Egress Gateway without file mount").Run(func(t TestHelper) {
+		t.NewSubTest("Egress Gateway without file mount").Run(func(t test.TestHelper) {
 			t.Log("Perform TLS origination with an egress gateway")
 
 			t.LogStep("Install external nginx")
@@ -80,7 +80,7 @@ func TestTLSOrigination(t *testing.T) {
 					"Expected Welcome to nginx; Got unexpected response"))
 		})
 
-		t.NewSubTest("mTLS with file mount").Run(func(t TestHelper) {
+		t.NewSubTest("mTLS with file mount").Run(func(t test.TestHelper) {
 			t.Log("Perform mTLS origination with an egress gateway")
 			t.Cleanup(func() {
 				app.Uninstall(t, app.NginxExternalMTLS(ns.MeshExternal))

--- a/pkg/tests/tasks/traffic/egress/egress_gateways_tls_sds_test.go
+++ b/pkg/tests/tasks/traffic/egress/egress_gateways_tls_sds_test.go
@@ -21,11 +21,11 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/tests/ossm"
 	"github.com/maistra/maistra-test-tool/pkg/util/ns"
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
-	. "github.com/maistra/maistra-test-tool/pkg/util/test"
+	"github.com/maistra/maistra-test-tool/pkg/util/test"
 )
 
 func TestTLSOriginationSDS(t *testing.T) {
-	NewTest(t).Id("T15").Groups(Full, InterOp, ARM).Run(func(t TestHelper) {
+	test.NewTest(t).Id("T15").Groups(test.Full, test.InterOp, test.ARM).Run(func(t test.TestHelper) {
 		t.Cleanup(func() {
 			oc.RecreateNamespace(t, ns.Bookinfo)
 			oc.RecreateNamespace(t, ns.MeshExternal)

--- a/pkg/tests/tasks/traffic/egress/egress_wildcard_hosts_test.go
+++ b/pkg/tests/tasks/traffic/egress/egress_wildcard_hosts_test.go
@@ -22,12 +22,11 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/check/assert"
 	"github.com/maistra/maistra-test-tool/pkg/util/ns"
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
-
-	. "github.com/maistra/maistra-test-tool/pkg/util/test"
+	"github.com/maistra/maistra-test-tool/pkg/util/test"
 )
 
 func TestEgressWildcard(t *testing.T) {
-	NewTest(t).Id("T16").Groups(Full, InterOp, ARM).Run(func(t TestHelper) {
+	test.NewTest(t).Id("T16").Groups(test.Full, test.InterOp, test.ARM).Run(func(t test.TestHelper) {
 		t.Log("This test checks if the wildcard in the ServiceEntry and Gateway works as expected for Egress traffic.")
 
 		ossm.DeployControlPlane(t)
@@ -38,7 +37,7 @@ func TestEgressWildcard(t *testing.T) {
 			app.Uninstall(t, app.Sleep(ns.Bookinfo))
 		})
 
-		t.NewSubTest("ServiceEntry").Run(func(t TestHelper) {
+		t.NewSubTest("ServiceEntry").Run(func(t test.TestHelper) {
 			t.LogStep("Configure ServiceEntry with wildcard host *.wikipedia.org")
 			oc.ApplyString(t, ns.Bookinfo, EgressWildcardServiceEntry)
 			t.Cleanup(func() {
@@ -48,7 +47,7 @@ func TestEgressWildcard(t *testing.T) {
 			assertExternalRequestSuccess(t, ns.Bookinfo)
 		})
 
-		t.NewSubTest("Gateway").Run(func(t TestHelper) {
+		t.NewSubTest("Gateway").Run(func(t test.TestHelper) {
 			t.LogStep("Configure egress Gateway with wildcard host *.wikipedia.org")
 			oc.ApplyTemplate(t, ns.Bookinfo, EgressWildcardGatewayTemplate, smcp)
 			t.Cleanup(func() {
@@ -60,7 +59,7 @@ func TestEgressWildcard(t *testing.T) {
 	})
 }
 
-func assertExternalRequestSuccess(t TestHelper, ns string) {
+func assertExternalRequestSuccess(t test.TestHelper, ns string) {
 	t.LogStep("Check external request to en.wikipedia.org and de.wikipedia.org")
 	app.ExecInSleepPod(t,
 		ns,

--- a/pkg/tests/tasks/traffic/fault_injection_test.go
+++ b/pkg/tests/tasks/traffic/fault_injection_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/ns"
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
 	"github.com/maistra/maistra-test-tool/pkg/util/retry"
-	. "github.com/maistra/maistra-test-tool/pkg/util/test"
+	"github.com/maistra/maistra-test-tool/pkg/util/test"
 )
 
 var (
@@ -40,7 +40,7 @@ var (
 )
 
 func TestFaultInjection(t *testing.T) {
-	NewTest(t).Id("T2").Groups(Full, InterOp, ARM).Run(func(t TestHelper) {
+	test.NewTest(t).Id("T2").Groups(test.Full, test.InterOp, test.ARM).Run(func(t test.TestHelper) {
 
 		t.Cleanup(func() {
 			oc.RecreateNamespace(t, ns.Bookinfo)
@@ -57,11 +57,11 @@ func TestFaultInjection(t *testing.T) {
 		oc.ApplyString(t, ns.Bookinfo, app.BookinfoVirtualServicesAllV1)
 		oc.ApplyString(t, ns.Bookinfo, app.BookinfoVirtualServiceReviewsV2)
 
-		t.NewSubTest("ratings-fault-delay").Run(func(t TestHelper) {
+		t.NewSubTest("ratings-fault-delay").Run(func(t test.TestHelper) {
 			oc.ApplyString(t, ns.Bookinfo, ratingsVirtualServiceWithFixedDelay)
 
 			t.LogStep("check if productpage shows 'error fetching product reviews' due to delay injection")
-			retry.UntilSuccess(t, func(t TestHelper) {
+			retry.UntilSuccess(t, func(t test.TestHelper) {
 				curl.Request(t,
 					app.BookinfoProductPageURL(t, meshNamespace),
 					curl.WithCookieJar(testUserCookieJar),
@@ -74,13 +74,13 @@ func TestFaultInjection(t *testing.T) {
 			})
 		})
 
-		t.NewSubTest("ratings-fault-abort").Run(func(t TestHelper) {
+		t.NewSubTest("ratings-fault-abort").Run(func(t test.TestHelper) {
 			oc.ApplyString(t, ns.Bookinfo, ratingsVirtualServiceWithHttpStatus500)
 
 			expectedResponseFile := TestreviewV2(t, "productpage-test-user-v2-rating-unavailable.html")
 
 			t.LogStep("check if productpage shows ratings service as unavailable due to abort injection")
-			retry.UntilSuccess(t, func(t TestHelper) {
+			retry.UntilSuccess(t, func(t test.TestHelper) {
 				curl.Request(t,
 					app.BookinfoProductPageURL(t, meshNamespace),
 					curl.WithCookieJar(testUserCookieJar),

--- a/pkg/tests/tasks/traffic/ingress/gatewayapi_test.go
+++ b/pkg/tests/tasks/traffic/ingress/gatewayapi_test.go
@@ -15,12 +15,11 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/retry"
 	"github.com/maistra/maistra-test-tool/pkg/util/shell"
 	"github.com/maistra/maistra-test-tool/pkg/util/test"
-	. "github.com/maistra/maistra-test-tool/pkg/util/test"
 	"github.com/maistra/maistra-test-tool/pkg/util/version"
 )
 
 func TestGatewayApi(t *testing.T) {
-	NewTest(t).Id("T41").Groups(Full, InterOp, ARM).Run(func(t TestHelper) {
+	test.NewTest(t).Id("T41").Groups(test.Full, test.InterOp, test.ARM).Run(func(t test.TestHelper) {
 		if env.GetSMCPVersion().LessThan(version.SMCP_2_3) {
 			t.Skip("TestGatewayApi was added in v2.3")
 		}
@@ -88,7 +87,7 @@ func TestGatewayApi(t *testing.T) {
 			oc.WaitCondition(t, ns.Foo, "Gateway", "gateway", gatewayapi.GetWaitingCondition(env.GetSMCPVersion()))
 
 			t.LogStep("Verfiy the GatewayApi access the httpbin service using curl")
-			retry.UntilSuccess(t, func(t TestHelper) {
+			retry.UntilSuccess(t, func(t test.TestHelper) {
 				oc.Exec(t,
 					pod.MatchingSelector("app=istio-ingressgateway", meshNamespace),
 					"istio-proxy",
@@ -134,7 +133,7 @@ func TestGatewayApi(t *testing.T) {
 			oc.WaitCondition(t, ns.Foo, "Gateway", "gateway", gatewayapi.GetWaitingCondition(env.GetSMCPVersion()))
 
 			t.LogStep("Verify the Gateway-Controller Profile access the httpbin service using curl")
-			retry.UntilSuccess(t, func(t TestHelper) {
+			retry.UntilSuccess(t, func(t test.TestHelper) {
 				oc.Exec(t,
 					pod.MatchingSelector("app=istiod", meshNamespace),
 					"discovery",

--- a/pkg/tests/tasks/traffic/ingress/ingress_gateways_test.go
+++ b/pkg/tests/tasks/traffic/ingress/ingress_gateways_test.go
@@ -29,12 +29,12 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
 	"github.com/maistra/maistra-test-tool/pkg/util/request"
 	"github.com/maistra/maistra-test-tool/pkg/util/retry"
-	. "github.com/maistra/maistra-test-tool/pkg/util/test"
+	"github.com/maistra/maistra-test-tool/pkg/util/test"
 	"github.com/maistra/maistra-test-tool/pkg/util/version"
 )
 
 func TestIngressGateways(t *testing.T) {
-	NewTest(t).Id("T8").Groups(Full, InterOp, ARM).Run(func(t TestHelper) {
+	test.NewTest(t).Id("T8").Groups(test.Full, test.InterOp, test.ARM).Run(func(t test.TestHelper) {
 
 		t.Cleanup(func() {
 			oc.RecreateNamespace(t, ns.Bookinfo)
@@ -47,7 +47,7 @@ func TestIngressGateways(t *testing.T) {
 
 		gatewayHTTP := istio.GetIngressGatewayHost(t, meshNamespace)
 
-		t.NewSubTest("TrafficManagement_ingress_status_200_test").Run(func(t TestHelper) {
+		t.NewSubTest("TrafficManagement_ingress_status_200_test").Run(func(t test.TestHelper) {
 			t.LogStep("Create httpbin Gateway and VirtualService with host set to httpbin.example.com")
 			oc.ApplyString(t, ns.Bookinfo, httpbinGateway1)
 
@@ -56,7 +56,7 @@ func TestIngressGateways(t *testing.T) {
 			}
 
 			t.LogStep("Check if httpbin service is reachable through istio-ingressgateway")
-			retry.UntilSuccess(t, func(t TestHelper) {
+			retry.UntilSuccess(t, func(t test.TestHelper) {
 				curl.Request(t,
 					fmt.Sprintf("http://%s/status/200", gatewayHTTP),
 					request.WithHost("httpbin.example.com"),
@@ -64,12 +64,12 @@ func TestIngressGateways(t *testing.T) {
 			})
 		})
 
-		t.NewSubTest("TrafficManagement_ingress_headers_test").Run(func(t TestHelper) {
+		t.NewSubTest("TrafficManagement_ingress_headers_test").Run(func(t test.TestHelper) {
 			t.LogStep("Create httpbin Gateway and VirtualService with host set to *")
 			oc.ApplyString(t, ns.Bookinfo, httpbinGateway2)
 
 			t.LogStep("Check if httpbin service is reachable through istio-ingressgateway")
-			retry.UntilSuccess(t, func(t TestHelper) {
+			retry.UntilSuccess(t, func(t test.TestHelper) {
 				curl.Request(t,
 					fmt.Sprintf("http://%s/headers", gatewayHTTP),
 					nil,

--- a/pkg/tests/tasks/traffic/ingress/secure_gateways_test.go
+++ b/pkg/tests/tasks/traffic/ingress/secure_gateways_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
 	"github.com/maistra/maistra-test-tool/pkg/util/request"
 	"github.com/maistra/maistra-test-tool/pkg/util/retry"
-	. "github.com/maistra/maistra-test-tool/pkg/util/test"
+	"github.com/maistra/maistra-test-tool/pkg/util/test"
 	"github.com/maistra/maistra-test-tool/pkg/util/version"
 )
 
@@ -48,7 +48,7 @@ var (
 )
 
 func TestSecureGateways(t *testing.T) {
-	NewTest(t).Id("T9").Groups(Full, InterOp, ARM).Run(func(t TestHelper) {
+	test.NewTest(t).Id("T9").Groups(test.Full, test.InterOp, test.ARM).Run(func(t test.TestHelper) {
 
 		t.Log("This test verifies secure gateways.")
 		t.Log("Doc reference: https://istio.io/latest/docs/tasks/traffic-management/ingress/secure-ingress/")
@@ -75,7 +75,7 @@ func TestSecureGateways(t *testing.T) {
 		helloWorldURL := "https://helloworld-v1.example.com:" + gatewayPort + "/hello"
 		teapotURL := "https://httpbin.example.com:" + gatewayPort + "/status/418"
 
-		t.NewSubTest("tls_single_host").Run(func(t TestHelper) {
+		t.NewSubTest("tls_single_host").Run(func(t test.TestHelper) {
 			t.LogStep("Configure a TLS ingress gateway for a single host")
 			oc.ApplyString(t, ns.Bookinfo, httpbinTLSGatewayHTTPS)
 
@@ -84,7 +84,7 @@ func TestSecureGateways(t *testing.T) {
 			}
 
 			t.LogStep("check if httpbin responds with teapot")
-			retry.UntilSuccess(t, func(t TestHelper) {
+			retry.UntilSuccess(t, func(t test.TestHelper) {
 				curl.Request(t,
 					teapotURL,
 					request.WithTLS(httpbinSampleCACert, "httpbin.example.com", gatewayHost, gatewayPort),
@@ -93,7 +93,7 @@ func TestSecureGateways(t *testing.T) {
 			})
 		})
 
-		t.NewSubTest("tls_multiple_hosts").Run(func(t TestHelper) {
+		t.NewSubTest("tls_multiple_hosts").Run(func(t test.TestHelper) {
 			t.LogStep("configure Gateway with multiple TLS hosts")
 			oc.ApplyString(t, ns.Bookinfo, gatewayMultipleHosts)
 
@@ -103,7 +103,7 @@ func TestSecureGateways(t *testing.T) {
 			}
 
 			t.LogStep("check if helloworld-v1 responds with 200 OK")
-			retry.UntilSuccess(t, func(t TestHelper) {
+			retry.UntilSuccess(t, func(t test.TestHelper) {
 				curl.Request(t,
 					helloWorldURL,
 					request.WithTLS(httpbinSampleCACert, "helloworld-v1.example.com", gatewayHost, gatewayPort),
@@ -111,7 +111,7 @@ func TestSecureGateways(t *testing.T) {
 			})
 
 			t.LogStep("check if httpbin responds with teapot")
-			retry.UntilSuccess(t, func(t TestHelper) {
+			retry.UntilSuccess(t, func(t test.TestHelper) {
 				curl.Request(t,
 					teapotURL,
 					request.WithTLS(httpbinSampleCACert, "httpbin.example.com", gatewayHost, gatewayPort),
@@ -119,7 +119,7 @@ func TestSecureGateways(t *testing.T) {
 			})
 		})
 
-		t.NewSubTest("mutual_tls").Run(func(t TestHelper) {
+		t.NewSubTest("mutual_tls").Run(func(t test.TestHelper) {
 			t.LogStep("configure Gateway with tls.mode=Mutual")
 			oc.CreateGenericSecretFromFiles(t, meshNamespace, "httpbin-credential",
 				"tls.key="+httpbinSampleServerCertKey,
@@ -132,7 +132,7 @@ func TestSecureGateways(t *testing.T) {
 			}
 
 			t.LogStep("check if SSL handshake fails when no client certificate is given")
-			retry.UntilSuccess(t, func(t TestHelper) {
+			retry.UntilSuccess(t, func(t test.TestHelper) {
 				curl.Request(t,
 					teapotURL,
 					request.WithTLS(httpbinSampleCACert, "httpbin.example.com", gatewayHost, gatewayPort),
@@ -148,7 +148,7 @@ func TestSecureGateways(t *testing.T) {
 			})
 
 			t.LogStep("check if SSL handshake succeeds when client certificate is given")
-			retry.UntilSuccess(t, func(t TestHelper) {
+			retry.UntilSuccess(t, func(t test.TestHelper) {
 				curl.Request(t,
 					teapotURL,
 					request.
@@ -158,7 +158,7 @@ func TestSecureGateways(t *testing.T) {
 			})
 		})
 
-		t.NewSubTest("mutual_tls_with_crl").Run(func(t TestHelper) {
+		t.NewSubTest("mutual_tls_with_crl").Run(func(t test.TestHelper) {
 			t.Log("Reference: https://issues.redhat.com/browse/OSSM-414")
 			if env.GetSMCPVersion().LessThan(version.SMCP_2_5) {
 				t.Skip("Skipping until 2.5")
@@ -173,7 +173,7 @@ func TestSecureGateways(t *testing.T) {
 
 			createRouteWithTLS(t, meshNamespace, "httpbin.example.com", "https", "istio-ingressgateway", "passthrough")
 			t.LogStep("check if SSL handshake fails when no client certificate is given")
-			retry.UntilSuccess(t, func(t TestHelper) {
+			retry.UntilSuccess(t, func(t test.TestHelper) {
 				curl.Request(t,
 					teapotURL,
 					request.WithTLS(httpbinSampleCACert, "httpbin.example.com", gatewayHost, gatewayPort),
@@ -190,7 +190,7 @@ func TestSecureGateways(t *testing.T) {
 			})
 
 			t.LogStep("check if SSL handshake succeeds when client certificate is given")
-			retry.UntilSuccess(t, func(t TestHelper) {
+			retry.UntilSuccess(t, func(t test.TestHelper) {
 				curl.Request(t,
 					teapotURL,
 					request.
@@ -200,7 +200,7 @@ func TestSecureGateways(t *testing.T) {
 			})
 
 			t.LogStep("check if SSL handshake fails when revoked client certificate is given")
-			retry.UntilSuccess(t, func(t TestHelper) {
+			retry.UntilSuccess(t, func(t test.TestHelper) {
 				curl.Request(t,
 					teapotURL,
 					request.

--- a/pkg/tests/tasks/traffic/request_routing_test.go
+++ b/pkg/tests/tasks/traffic/request_routing_test.go
@@ -26,11 +26,11 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/ns"
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
 	"github.com/maistra/maistra-test-tool/pkg/util/retry"
-	. "github.com/maistra/maistra-test-tool/pkg/util/test"
+	"github.com/maistra/maistra-test-tool/pkg/util/test"
 )
 
 func TestRequestRouting(t *testing.T) {
-	NewTest(t).Id("T1").Groups(Smoke, Full, InterOp, ARM).Run(func(t TestHelper) {
+	test.NewTest(t).Id("T1").Groups(test.Smoke, test.Full, test.InterOp, test.ARM).Run(func(t test.TestHelper) {
 
 		t.Cleanup(func() {
 			oc.RecreateNamespace(t, ns.Bookinfo)
@@ -46,13 +46,13 @@ func TestRequestRouting(t *testing.T) {
 		productpageURL := app.BookinfoProductPageURL(t, meshNamespace)
 		testUserCookieJar := app.BookinfoLogin(t, meshNamespace)
 
-		t.NewSubTest("not-logged-in").Run(func(t TestHelper) {
+		t.NewSubTest("not-logged-in").Run(func(t test.TestHelper) {
 			oc.ApplyString(t, ns.Bookinfo, app.BookinfoVirtualServicesAllV1)
 
 			expectedResponseFile := TestreviewV1(t, "productpage-normal-user-v1.html")
 
 			t.LogStep("get productpage without logging in; expect to get reviews-v1 (5x)")
-			retry.UntilSuccess(t, func(t TestHelper) {
+			retry.UntilSuccess(t, func(t test.TestHelper) {
 				for i := 0; i < 5; i++ {
 					curl.Request(t,
 						productpageURL, nil,
@@ -65,13 +65,13 @@ func TestRequestRouting(t *testing.T) {
 			})
 		})
 
-		t.NewSubTest("logged-in").Run(func(t TestHelper) {
+		t.NewSubTest("logged-in").Run(func(t test.TestHelper) {
 			oc.ApplyString(t, ns.Bookinfo, app.BookinfoVirtualServiceReviewsV2)
 
 			expectedResponseFile2 := TestreviewV2(t, "productpage-test-user-v2.html")
 
 			t.LogStep("get productpage as logged-in user; expect to get reviews-v2 (5x)")
-			retry.UntilSuccess(t, func(t TestHelper) {
+			retry.UntilSuccess(t, func(t test.TestHelper) {
 				for i := 0; i < 5; i++ {
 					curl.Request(t,
 						productpageURL,

--- a/pkg/tests/tasks/traffic/request_timeouts_test.go
+++ b/pkg/tests/tasks/traffic/request_timeouts_test.go
@@ -28,14 +28,14 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/ns"
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
 	"github.com/maistra/maistra-test-tool/pkg/util/retry"
-	. "github.com/maistra/maistra-test-tool/pkg/util/test"
+	"github.com/maistra/maistra-test-tool/pkg/util/test"
 )
 
 //go:embed yaml/virtualservice-reviews-ratings-timeout.yaml
 var reviewTimeout string
 
 func TestRequestTimeouts(t *testing.T) {
-	NewTest(t).Id("T5").Groups(Full, InterOp, ARM).Run(func(t TestHelper) {
+	test.NewTest(t).Id("T5").Groups(test.Full, test.InterOp, test.ARM).Run(func(t test.TestHelper) {
 
 		t.Cleanup(func() {
 			oc.RecreateNamespace(t, ns.Bookinfo)
@@ -55,7 +55,7 @@ func TestRequestTimeouts(t *testing.T) {
 
 		expectedResponseFile := TestreviewV1(t, "productpage-normal-user-v1.html")
 
-		retry.UntilSuccess(t, func(t TestHelper) {
+		retry.UntilSuccess(t, func(t test.TestHelper) {
 			curl.Request(t,
 				productpageURL, nil,
 				assert.ResponseMatchesFile(
@@ -69,7 +69,7 @@ func TestRequestTimeouts(t *testing.T) {
 		oc.ApplyString(t, ns.Bookinfo, reviewTimeout)
 
 		t.LogStep("check if productpage shows 'error fetching product reviews' due to delay and timeout injection")
-		retry.UntilSuccess(t, func(t TestHelper) {
+		retry.UntilSuccess(t, func(t test.TestHelper) {
 			for i := 0; i <= 5; i++ {
 				curl.Request(t,
 					productpageURL, nil,

--- a/pkg/tests/tasks/traffic/traffic_mirroring_test.go
+++ b/pkg/tests/tasks/traffic/traffic_mirroring_test.go
@@ -19,17 +19,17 @@ import (
 
 	"github.com/maistra/maistra-test-tool/pkg/app"
 	"github.com/maistra/maistra-test-tool/pkg/tests/ossm"
-	. "github.com/maistra/maistra-test-tool/pkg/util"
+	"github.com/maistra/maistra-test-tool/pkg/util"
 	"github.com/maistra/maistra-test-tool/pkg/util/check/assert"
 	"github.com/maistra/maistra-test-tool/pkg/util/ns"
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
 	"github.com/maistra/maistra-test-tool/pkg/util/pod"
 	"github.com/maistra/maistra-test-tool/pkg/util/retry"
-	. "github.com/maistra/maistra-test-tool/pkg/util/test"
+	"github.com/maistra/maistra-test-tool/pkg/util/test"
 )
 
 func TestMirroring(t *testing.T) {
-	NewTest(t).Id("T7").Groups(Full, InterOp, ARM).Run(func(t TestHelper) {
+	test.NewTest(t).Id("T7").Groups(test.Full, test.InterOp, test.ARM).Run(func(t test.TestHelper) {
 
 		t.Cleanup(func() {
 			oc.RecreateNamespace(t, ns.Bookinfo)
@@ -43,12 +43,12 @@ func TestMirroring(t *testing.T) {
 			app.HttpbinV2(ns.Bookinfo),
 			app.Sleep(ns.Bookinfo))
 
-		t.NewSubTest("no mirroring").Run(func(t TestHelper) {
+		t.NewSubTest("no mirroring").Run(func(t test.TestHelper) {
 			oc.ApplyString(t, ns.Bookinfo, httpbinAllv1)
 
 			t.LogStep("sending HTTP request from sleep to httpbin-v1, not expecting mirroring to v2")
-			retry.UntilSuccess(t, func(t TestHelper) {
-				nonce := NewNonce()
+			retry.UntilSuccess(t, func(t test.TestHelper) {
+				nonce := util.NewNonce()
 
 				oc.Exec(t,
 					pod.MatchingSelector("app=sleep", ns.Bookinfo),
@@ -73,12 +73,12 @@ func TestMirroring(t *testing.T) {
 			})
 		})
 
-		t.NewSubTest("mirroring to httpbin-v2").Run(func(t TestHelper) {
+		t.NewSubTest("mirroring to httpbin-v2").Run(func(t test.TestHelper) {
 			oc.ApplyString(t, ns.Bookinfo, httpbinMirrorv2)
 
 			t.LogStep("sending HTTP request from sleep to httpbin-v1, expecting mirroring to v2")
-			retry.UntilSuccess(t, func(t TestHelper) {
-				nonce := NewNonce()
+			retry.UntilSuccess(t, func(t test.TestHelper) {
+				nonce := util.NewNonce()
 
 				oc.Exec(t,
 					pod.MatchingSelector("app=sleep", ns.Bookinfo),


### PR DESCRIPTION
1. Replace `. "github.com/maistra/maistra-test-tool/pkg/util/test"` with `"github.com/maistra/maistra-test-tool/pkg/util/test"` as dot import since dot import can be called bad practice and general import is used for test package more.
2. Replace `. "github.com/maistra/maistra-test-tool/pkg/util/test"` for the same reason
3. Replace `namespaces "github.com/maistra/maistra-test-tool/pkg/util/ns"` import to just `"github.com/maistra/maistra-test-tool/pkg/util/ns"`
