### PR TITLE
[OSSM-6574]: MTT-update the httpbin image for IBM-Z

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -52,7 +52,7 @@ httpbin:
   x86: quay.io/openshifttest/httpbin:multiarch
   arm64: quay.io/openshifttest/httpbin:multiarch
   p: quay.io/maistra/kennethreitz-httpbin:0.0-ibm-p
-  z: quay.io/maistra/httpbin:0.0-ibm-z
+  z: quay.io/maistra/httpbin:0.1-ibm-Z
 
 sleep:
   x86: quay.io/openshifttest/sleep:multiarch


### PR DESCRIPTION
TestIngressGateways
TestSecureGateways
TestOperatorCanUpdatePrometheusConfigMap

All these test cases are failing with the old image. 

tested locally with the IBM-Z cluster, all test cases are passed as expected. 