### PR TITLE
[OSSM-6572] MTT: Delete redunduncies in test pkg import, cleanup

### DIFF
--- a/pkg/tests/ossm/prometheus_scoped_scraping_test.go
+++ b/pkg/tests/ossm/prometheus_scoped_scraping_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/check/require"
 	"github.com/maistra/maistra-test-tool/pkg/util/curl"
 	"github.com/maistra/maistra-test-tool/pkg/util/env"
-	namespaces "github.com/maistra/maistra-test-tool/pkg/util/ns"
+	"github.com/maistra/maistra-test-tool/pkg/util/ns"
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
 	"github.com/maistra/maistra-test-tool/pkg/util/pod"
 	"github.com/maistra/maistra-test-tool/pkg/util/retry"
@@ -168,10 +168,10 @@ func TestOperatorCanUpdatePrometheusConfigMap(t *testing.T) {
 			oc.DeleteFromString(t, meshNamespace, smmr)
 
 			testPrometheusConfigWithAsserts(t,
-				assertConfigMapDoesNotContainNamespace(namespaces.Bar),
-				assertConfigMapDoesNotContainNamespace(namespaces.Bookinfo),
-				assertConfigMapDoesNotContainNamespace(namespaces.Foo),
-				assertConfigMapDoesNotContainNamespace(namespaces.Legacy),
+				assertConfigMapDoesNotContainNamespace(ns.Bar),
+				assertConfigMapDoesNotContainNamespace(ns.Bookinfo),
+				assertConfigMapDoesNotContainNamespace(ns.Foo),
+				assertConfigMapDoesNotContainNamespace(ns.Legacy),
 			)
 			checkConfigurationReloadingTriggered(t, start)
 			checkPermissionError(t)

--- a/pkg/tests/ossm/ratelimit_test.go
+++ b/pkg/tests/ossm/ratelimit_test.go
@@ -26,9 +26,9 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
 	"github.com/maistra/maistra-test-tool/pkg/util/retry"
 	"github.com/maistra/maistra-test-tool/pkg/util/shell"
-	"github.com/maistra/maistra-test-tool/pkg/util/test"
-	. "github.com/maistra/maistra-test-tool/pkg/util/test"
 	"github.com/maistra/maistra-test-tool/pkg/util/version"
+
+	. "github.com/maistra/maistra-test-tool/pkg/util/test"
 )
 
 var (
@@ -76,7 +76,7 @@ func TestRateLimiting(t *testing.T) {
 
 		productPageURL := app.BookinfoProductPageURL(t, meshNamespace)
 		t.LogStep("Make 3 request to validate rate limit: first should work, second should fail with 429, third should work again after wait more than 1 seconds")
-		retry.UntilSuccess(t, func(t test.TestHelper) {
+		retry.UntilSuccess(t, func(t TestHelper) {
 			curl.Request(t, productPageURL, nil, assert.ResponseStatus(200))
 			curl.Request(t, productPageURL, nil, assert.ResponseStatus(429))
 			time.Sleep(time.Second * 5) // wait 5 seconds to make sure the rate limit is reset

--- a/pkg/tests/ossm/smcp_must_gather_test.go
+++ b/pkg/tests/ossm/smcp_must_gather_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/env"
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
 	"github.com/maistra/maistra-test-tool/pkg/util/shell"
-	"github.com/maistra/maistra-test-tool/pkg/util/test"
+
 	. "github.com/maistra/maistra-test-tool/pkg/util/test"
 )
 
@@ -56,7 +56,7 @@ func TestMustGather(t *testing.T) {
 				"Must gather completed successfully",
 				"Must gather failed"))
 
-		t.NewSubTest("dump files and proxy stats files exist for pods").Run(func(t test.TestHelper) {
+		t.NewSubTest("dump files and proxy stats files exist for pods").Run(func(t TestHelper) {
 			t.LogStep("Check dump files exist under the directory of namespace directory")
 			t.Log("Verify these files:")
 			t.Log("config_dump_istiod.json, config_dump_proxy.json, proxy_stats")
@@ -159,7 +159,7 @@ func assertFilesExist(t TestHelper, dir string, files ...string) {
 	}
 }
 
-func checkFileContents(t test.TestHelper, dir string, file string, checks ...common.CheckFunc) {
+func checkFileContents(t TestHelper, dir string, file string, checks ...common.CheckFunc) {
 	path := filepath.Join(dir, file)
 	filePath := shell.Execute(t, fmt.Sprintf("find %s", path))
 	data, err := os.ReadFile(filePath[:len(filePath)-1])

--- a/pkg/tests/ossm/smm_test.go
+++ b/pkg/tests/ossm/smm_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
 	"github.com/maistra/maistra-test-tool/pkg/util/retry"
 	"github.com/maistra/maistra-test-tool/pkg/util/shell"
-	"github.com/maistra/maistra-test-tool/pkg/util/test"
+
 	. "github.com/maistra/maistra-test-tool/pkg/util/test"
 )
 
@@ -42,7 +42,7 @@ func TestSMMRAutoCreationAndDeletion(t *testing.T) {
 			oc.WaitSMMRReady(t, meshNamespace)
 
 			t.LogStep("Check both namespaces are shown as members in SMMR")
-			retry.UntilSuccess(t, func(t test.TestHelper) {
+			retry.UntilSuccess(t, func(t TestHelper) {
 				shell.Execute(t,
 					fmt.Sprintf(`oc get smmr default -n %s -o=jsonpath='{.status.members[*]}{"\n"}'`, meshNamespace),
 					assert.OutputContains(foo, "SMMR has the member foo", "SMMR does not have the namespaces foo and bar"),
@@ -59,7 +59,7 @@ func TestSMMRAutoCreationAndDeletion(t *testing.T) {
 			oc.DeleteFromString(t, bar, smm)
 
 			t.LogStep("Check if SMMR becomes ready (it won't be if it gets deleted)")
-			retry.UntilSuccess(t, func(t test.TestHelper) {
+			retry.UntilSuccess(t, func(t TestHelper) {
 				oc.WaitSMMRReady(t, meshNamespace)
 			})
 		})
@@ -73,7 +73,7 @@ func TestSMMRAutoCreationAndDeletion(t *testing.T) {
 			oc.DeleteFromString(t, foo, smm)
 
 			t.LogStep("Check that SMMR is deleted")
-			retry.UntilSuccess(t, func(t test.TestHelper) {
+			retry.UntilSuccess(t, func(t TestHelper) {
 				shell.Execute(t,
 					fmt.Sprintf("oc get smmr -n %s default || true", meshNamespace),
 					assert.OutputContains("not found",
@@ -104,7 +104,7 @@ func TestSMMReconciliation(t *testing.T) {
 		oc.RemoveLabel(t, "", "Namespace", ns.Bookinfo, "maistra.io/member-of")
 
 		t.LogStep("Check if label was added back by the operator")
-		retry.UntilSuccess(t, func(t test.TestHelper) {
+		retry.UntilSuccess(t, func(t TestHelper) {
 			oc.GetYaml(t,
 				"", "namespace", ns.Bookinfo,
 				assert.OutputContains(

--- a/pkg/tests/ossm/smoke_test.go
+++ b/pkg/tests/ossm/smoke_test.go
@@ -25,9 +25,9 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/env"
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
 	"github.com/maistra/maistra-test-tool/pkg/util/retry"
-	"github.com/maistra/maistra-test-tool/pkg/util/test"
-	. "github.com/maistra/maistra-test-tool/pkg/util/test"
 	"github.com/maistra/maistra-test-tool/pkg/util/version"
+
+	. "github.com/maistra/maistra-test-tool/pkg/util/test"
 )
 
 var (
@@ -179,7 +179,7 @@ func assertProxiesReadyInLessThan10Seconds(t TestHelper, ns string) {
 	}
 }
 
-func assertSMCPDeploysAndIsReady(t test.TestHelper, ver version.Version) {
+func assertSMCPDeploysAndIsReady(t TestHelper, ver version.Version) {
 	t.LogStep("Install SMCP")
 	InstallSMCPVersion(t, meshNamespace, ver)
 	oc.WaitSMCPReady(t, meshNamespace, smcpName)
@@ -188,7 +188,7 @@ func assertSMCPDeploysAndIsReady(t test.TestHelper, ver version.Version) {
 	oc.WaitSMCPReady(t, meshNamespace, smcpName)
 }
 
-func assertRoutesExist(t test.TestHelper) {
+func assertRoutesExist(t TestHelper) {
 	t.Log("Related issue: https://issues.redhat.com/browse/OSSM-4069")
 	retry.UntilSuccess(t, func(t TestHelper) {
 		oc.Get(t,

--- a/pkg/tests/tasks/extensions/threescale_wasm_plugin_test.go
+++ b/pkg/tests/tasks/extensions/threescale_wasm_plugin_test.go
@@ -157,5 +157,3 @@ func TestThreeScaleWasmPlugin(t *testing.T) {
 		}
 	})
 }
-
-//fmt.Sprintf(`curl http://httpbin:8000/headers -H "Authorization: Bearer %s" -s -o /dev/null -w "%%{http_code}"`, token),

--- a/pkg/tests/tasks/traffic/circuit_breaking_test.go
+++ b/pkg/tests/tasks/traffic/circuit_breaking_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
 	"github.com/maistra/maistra-test-tool/pkg/util/pod"
 	"github.com/maistra/maistra-test-tool/pkg/util/retry"
-	"github.com/maistra/maistra-test-tool/pkg/util/test"
 
 	. "github.com/maistra/maistra-test-tool/pkg/util/test"
 )
@@ -51,7 +50,7 @@ func TestCircuitBreaking(t *testing.T) {
 		oc.ApplyString(t, ns.Bookinfo, httpbinCircuitBreaker)
 
 		t.LogStep("Verify connection with curl: expect 200 OK")
-		retry.UntilSuccess(t, func(t test.TestHelper) {
+		retry.UntilSuccess(t, func(t TestHelper) {
 			httpbinIP := oc.GetServiceClusterIP(t, ns.Bookinfo, "httpbin")
 			oc.Exec(t,
 				pod.MatchingSelector("app=fortio", ns.Bookinfo),
@@ -66,7 +65,7 @@ func TestCircuitBreaking(t *testing.T) {
 		reqCount := 50
 		t.LogStep("Trip the circuit breaker by sending 50 requests to httpbin with 2 connections")
 		t.Log("We expect request with response code 503")
-		retry.UntilSuccess(t, func(t test.TestHelper) {
+		retry.UntilSuccess(t, func(t TestHelper) {
 			httpbinIP := oc.GetServiceClusterIP(t, ns.Bookinfo, "httpbin")
 			msg := oc.Exec(t,
 				pod.MatchingSelector("app=fortio", ns.Bookinfo),
@@ -94,7 +93,7 @@ func TestCircuitBreaking(t *testing.T) {
 	})
 }
 
-func getNumberOfResponses(t test.TestHelper, msg string, codeText string) int {
+func getNumberOfResponses(t TestHelper, msg string, codeText string) int {
 	re := regexp.MustCompile(codeText)
 	line := re.FindStringSubmatch(msg)[0]
 	re = regexp.MustCompile(`: [\d]+`)
@@ -107,7 +106,7 @@ func getNumberOfResponses(t test.TestHelper, msg string, codeText string) int {
 	return count
 }
 
-func assertProxyContainsUpstreamRqPendingOverflow(t test.TestHelper, output string) {
+func assertProxyContainsUpstreamRqPendingOverflow(t TestHelper, output string) {
 	var v int
 	scanner := bufio.NewScanner(strings.NewReader(output))
 	for scanner.Scan() {

--- a/pkg/tests/tasks/traffic/ingress/gatewayapi_test.go
+++ b/pkg/tests/tasks/traffic/ingress/gatewayapi_test.go
@@ -14,9 +14,9 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/pod"
 	"github.com/maistra/maistra-test-tool/pkg/util/retry"
 	"github.com/maistra/maistra-test-tool/pkg/util/shell"
-	"github.com/maistra/maistra-test-tool/pkg/util/test"
-	. "github.com/maistra/maistra-test-tool/pkg/util/test"
 	"github.com/maistra/maistra-test-tool/pkg/util/version"
+
+	. "github.com/maistra/maistra-test-tool/pkg/util/test"
 )
 
 func TestGatewayApi(t *testing.T) {
@@ -35,7 +35,7 @@ func TestGatewayApi(t *testing.T) {
 
 		oc.CreateNamespace(t, ns.Foo)
 
-		t.NewSubTest("Deploy the Kubernetes Gateway API").Run(func(t test.TestHelper) {
+		t.NewSubTest("Deploy the Kubernetes Gateway API").Run(func(t TestHelper) {
 
 			t.Cleanup(func() {
 				oc.RecreateNamespace(t, meshNamespace)
@@ -99,7 +99,7 @@ func TestGatewayApi(t *testing.T) {
 			})
 		})
 
-		t.NewSubTest("Deploy the Gateway-Controller Profile").Run(func(t test.TestHelper) {
+		t.NewSubTest("Deploy the Gateway-Controller Profile").Run(func(t TestHelper) {
 			if env.GetSMCPVersion().LessThan(version.SMCP_2_4) {
 				t.Skip("Gateway-Controller Profile was added in v2.4")
 			}


### PR DESCRIPTION
Based on discussion: https://github.com/maistra/maistra-test-tool/pull/687

1. In case of `test` pkg redundant import (general and dot) hold dot import.
Redundancy example:
```
	"github.com/maistra/maistra-test-tool/pkg/util/test"
	. "github.com/maistra/maistra-test-tool/pkg/util/test"
```
2. Replace `namespaces "github.com/maistra/maistra-test-tool/pkg/util/ns"` import to just `"github.com/maistra/maistra-test-tool/pkg/util/ns"`
3. Clean one accidentally added commentary