### PR TITLE
[OSSM-6582]  MTT: Fixing the flaky for the Prometheus pod

### DIFF
--- a/pkg/tests/tasks/observability/custom_prometheus_test.go
+++ b/pkg/tests/tasks/observability/custom_prometheus_test.go
@@ -53,6 +53,10 @@ func TestCustomPrometheus(t *testing.T) {
 
 		t.LogStep("Installing custom Prometheus")
 		installPrometheus(t, customPrometheusNs, meshNamespace, ns.Bookinfo)
+		retry.UntilSuccess(t, func(t test.TestHelper) {
+			prometheusPod := pod.MatchingSelector("app.kubernetes.io/name=prometheus-operator", customPrometheusNs)
+			oc.WaitPodRunning(t, prometheusPod)
+		})
 
 		t.LogStep("Intalling Bookinfo app")
 		oc.WaitSMCPReady(t, meshNamespace, "basic")


### PR DESCRIPTION
TestCustomPrometheus this test case is failing, the test case is running before the operator is installed.

added the step to check the pod, once the Prometheus operator pod is ready then it would be easy to verify the next steps. 
