### PR TITLE
Update files to be able to work with 2.6.x version

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ This command runs the entire test suite against the minimum supported `ServiceMe
 
 #### Running against a specific Operator version
 
-By default, maistra-test-tool assumes that the OSSM Operator version is `2.5.0` and runs tests against the `v2.3`, `v2.4`, and `v2.5` version of the ServiceMeshControlPlane.
-To run against the '2.4.x' version of the Operator, run the tests with the `OPERATOR_VERSION` environment variable set to `2.4.x`. For example, for Operator version `2.4.2`, run the tests as follows:
+By default, maistra-test-tool assumes that the OSSM Operator version is `2.6.0` and runs tests against the `v2.4`, `v2.5`, and `v2.6` version of the ServiceMeshControlPlane.
+To run against the '2.5.x' version of the Operator, run the tests with the `OPERATOR_VERSION` environment variable set to `2.5.x`. For example, for Operator version `2.5.2`, run the tests as follows:
 
 ```console
-OPERATOR_VERSION=2.4.2 make test
+OPERATOR_VERSION=2.5.2 make test
 ```
 
 ### Running a group of tests

--- a/pkg/tests/tasks/extensions/threescale_wasm_plugin_test.go
+++ b/pkg/tests/tasks/extensions/threescale_wasm_plugin_test.go
@@ -76,7 +76,7 @@ func TestThreeScaleWasmPlugin(t *testing.T) {
 
 		t.LogStep("Deploy httpbin and configure its gateway and routing")
 		app.InstallAndWaitReady(t, app.Httpbin(ns.Foo))
-		oc.ApplyFile(t, ns.Foo, "https://raw.githubusercontent.com/maistra/istio/maistra-2.4/samples/httpbin/httpbin-gateway.yaml")
+		oc.ApplyFile(t, ns.Foo, "https://raw.githubusercontent.com/maistra/istio/maistra-2.6/samples/httpbin/httpbin-gateway.yaml")
 
 		t.LogStep("Verify that a request to the ingress gateway with token returns 200")
 		ingressGatewayHost := istio.GetIngressGatewayHost(t, meshNamespace)

--- a/pkg/tests/tasks/observability/federated_openshift_monitoring_test.go
+++ b/pkg/tests/tasks/observability/federated_openshift_monitoring_test.go
@@ -49,7 +49,7 @@ func TestFederatedOpenShiftMonitoring(t *testing.T) {
 		oc.WaitAllPodsReady(t, ns.Foo)
 
 		t.LogStep("Generate some ingress traffic")
-		oc.ApplyFile(t, ns.Foo, "https://raw.githubusercontent.com/maistra/istio/maistra-2.5/samples/httpbin/httpbin-gateway.yaml")
+		oc.ApplyFile(t, ns.Foo, "https://raw.githubusercontent.com/maistra/istio/maistra-2.6/samples/httpbin/httpbin-gateway.yaml")
 		httpbinURL := fmt.Sprintf("http://%s/headers", istio.GetIngressGatewayHost(t, meshNamespace))
 		retry.UntilSuccess(t, func(t test.TestHelper) {
 			curl.Request(t, httpbinURL, nil, assert.ResponseStatus(http.StatusOK))

--- a/pkg/tests/tasks/observability/openshift_monitoring_test.go
+++ b/pkg/tests/tasks/observability/openshift_monitoring_test.go
@@ -177,7 +177,7 @@ func waitKialiAndVerifyIsReconciled(t test.TestHelper) {
 
 func generateTrafficAndcheckMetrics(t test.TestHelper, thanosToken string) {
 	t.LogStep("Generate some ingress traffic")
-	oc.ApplyFile(t, ns.Foo, "https://raw.githubusercontent.com/maistra/istio/maistra-2.5/samples/httpbin/httpbin-gateway.yaml")
+	oc.ApplyFile(t, ns.Foo, "https://raw.githubusercontent.com/maistra/istio/maistra-2.6/samples/httpbin/httpbin-gateway.yaml")
 	httpbinURL := fmt.Sprintf("http://%s/headers", istio.GetIngressGatewayHost(t, meshNamespace))
 	retry.UntilSuccess(t, func(t test.TestHelper) {
 		curl.Request(t, httpbinURL, nil, assert.ResponseStatus(http.StatusOK))

--- a/pkg/tests/tasks/security/certmanager/istio_csr_test.go
+++ b/pkg/tests/tasks/security/certmanager/istio_csr_test.go
@@ -103,7 +103,7 @@ func TestIstioCsr(t *testing.T) {
 		app.AssertSleepPodRequestSuccess(t, ns.Foo, "http://httpbin:8000/ip")
 
 		t.LogStep("Check mTLS traffic from ingress gateway to httpbin")
-		oc.ApplyFile(t, ns.Foo, "https://raw.githubusercontent.com/maistra/istio/maistra-2.5/samples/httpbin/httpbin-gateway.yaml")
+		oc.ApplyFile(t, ns.Foo, "https://raw.githubusercontent.com/maistra/istio/maistra-2.6/samples/httpbin/httpbin-gateway.yaml")
 		httpbinURL := fmt.Sprintf("http://%s/headers", istio.GetIngressGatewayHost(t, meshNamespace))
 		retry.UntilSuccess(t, func(t test.TestHelper) {
 			curl.Request(t, httpbinURL, nil, assert.ResponseStatus(http.StatusOK))

--- a/pkg/tests/tasks/security/certmanager/plugin_ca_test.go
+++ b/pkg/tests/tasks/security/certmanager/plugin_ca_test.go
@@ -80,7 +80,7 @@ func TestPluginCaCert(t *testing.T) {
 		app.AssertSleepPodRequestSuccess(t, ns.Foo, "http://httpbin:8000/ip")
 
 		t.LogStep("Check mTLS traffic from ingress gateway to httpbin")
-		oc.ApplyFile(t, ns.Foo, "https://raw.githubusercontent.com/maistra/istio/maistra-2.5/samples/httpbin/httpbin-gateway.yaml")
+		oc.ApplyFile(t, ns.Foo, "https://raw.githubusercontent.com/maistra/istio/maistra-2.6/samples/httpbin/httpbin-gateway.yaml")
 		httpbinURL := fmt.Sprintf("http://%s/headers", istio.GetIngressGatewayHost(t, meshNamespace))
 		retry.UntilSuccess(t, func(t test.TestHelper) {
 			curl.Request(t, httpbinURL, nil, assert.ResponseStatus(http.StatusOK))

--- a/pkg/tests/tasks/traffic/ingress/gatewayapi_test.go
+++ b/pkg/tests/tasks/traffic/ingress/gatewayapi_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
 	"github.com/maistra/maistra-test-tool/pkg/util/pod"
 	"github.com/maistra/maistra-test-tool/pkg/util/retry"
-	"github.com/maistra/maistra-test-tool/pkg/util/shell"
 	"github.com/maistra/maistra-test-tool/pkg/util/version"
 
 	. "github.com/maistra/maistra-test-tool/pkg/util/test"
@@ -30,8 +29,7 @@ func TestGatewayApi(t *testing.T) {
 		ossm.DeployControlPlane(t)
 
 		t.LogStep("Install Gateway API CRD's")
-		shell.Executef(t, "kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null && echo 'Gateway API CRDs already installed' || kubectl apply -k github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=%s",
-			gatewayapi.GetSupportedVersion(env.GetSMCPVersion()))
+		gatewayapi.InstallSupportedVersion(t, env.GetSMCPVersion())
 
 		oc.CreateNamespace(t, ns.Foo)
 

--- a/pkg/util/env/env.go
+++ b/pkg/util/env/env.go
@@ -50,11 +50,11 @@ func GetDefaultMeshNamespace() string {
 }
 
 func GetSMCPVersion() version.Version {
-	return version.ParseVersion(getenv("SMCP_VERSION", "v2.5"))
+	return version.ParseVersion(getenv("SMCP_VERSION", "v2.6"))
 }
 
 func GetOperatorVersion() version.Version {
-	return version.ParseVersion(getenv("OPERATOR_VERSION", "v2.5"))
+	return version.ParseVersion(getenv("OPERATOR_VERSION", "v2.6"))
 }
 
 func GetArch() string {

--- a/pkg/util/gatewayapi/gatewayapi.go
+++ b/pkg/util/gatewayapi/gatewayapi.go
@@ -1,21 +1,27 @@
 package gatewayapi
 
 import (
+	"github.com/maistra/maistra-test-tool/pkg/util/shell"
+	"github.com/maistra/maistra-test-tool/pkg/util/test"
 	"github.com/maistra/maistra-test-tool/pkg/util/version"
 )
 
-func GetSupportedVersion(smcp version.Version) string {
+func InstallSupportedVersion(t test.TestHelper, smcp version.Version) {
+	shell.Executef(t, "kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null && echo 'Gateway API CRDs already installed' || kubectl apply -k %s", getSupportedVersion(smcp))
+}
+
+func getSupportedVersion(smcp version.Version) string {
 	switch smcp {
 	case version.SMCP_2_3:
-		return "v0.5.1"
+		return "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.5.1"
 	case version.SMCP_2_4:
-		return "v0.5.1"
+		return "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.5.1"
 	case version.SMCP_2_5:
-		return "v0.6.2"
+		return "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.6.2"
 	case version.SMCP_2_6:
-		return "v1.0.0"
+		return "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v1.0.0"
 	default:
-		return "v0.6.2"
+		return "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v1.0.0"
 	}
 }
 

--- a/pkg/util/gatewayapi/gatewayapi.go
+++ b/pkg/util/gatewayapi/gatewayapi.go
@@ -12,6 +12,8 @@ func GetSupportedVersion(smcp version.Version) string {
 		return "v0.5.1"
 	case version.SMCP_2_5:
 		return "v0.6.2"
+	case version.SMCP_2_6:
+		return "v1.0.0"
 	default:
 		return "v0.6.2"
 	}
@@ -25,6 +27,8 @@ func GetDefaultServiceName(smcp version.Version, gatewayName string, className s
 		return gatewayName
 	case version.SMCP_2_5:
 		return gatewayName + "-" + className
+	case version.SMCP_2_6:
+		return gatewayName + "-" + className
 	default:
 		return gatewayName + "-" + className
 	}
@@ -37,6 +41,8 @@ func GetWaitingCondition(smcp version.Version) string {
 	case version.SMCP_2_4:
 		return "Ready"
 	case version.SMCP_2_5:
+		return "Programmed"
+	case version.SMCP_2_6:
 		return "Programmed"
 	default:
 		return "Programmed"

--- a/pkg/util/version/smcp_version.go
+++ b/pkg/util/version/smcp_version.go
@@ -7,4 +7,5 @@ var (
 	SMCP_2_3 = ParseVersion("v2.3")
 	SMCP_2_4 = ParseVersion("v2.4")
 	SMCP_2_5 = ParseVersion("v2.5")
+	SMCP_2_6 = ParseVersion("v2.6")
 )

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-OPERATOR_VERSION=${OPERATOR_VERSION:-"2.5.0"}
+OPERATOR_VERSION=${OPERATOR_VERSION:-"2.6.0"}
 OPERATOR_VERSION="${OPERATOR_VERSION#v}" # remove "v" prefix if necessary
 
 echo "OSSM Operator version is $OPERATOR_VERSION"
@@ -11,7 +11,8 @@ case "$OPERATOR_VERSION" in
     2.3.*) SUPPORTED_VERSIONS=("v2.1" "v2.2" "v2.3") ;;
     2.4.*) SUPPORTED_VERSIONS=("v2.2" "v2.3" "v2.4") ;;
     2.5.*) SUPPORTED_VERSIONS=("v2.3" "v2.4" "v2.5") ;;
-    *) echo "ERROR: unknown operator version: $OPERATOR_VERSION; expect either 2.3.x, 2.4.x or 2.5.x"; exit 1 ;;
+    2.6.*) SUPPORTED_VERSIONS=("v2.4" "v2.5" "v2.6") ;;
+    *) echo "ERROR: unknown operator version: $OPERATOR_VERSION; expect either 2.3.x, 2.4.x, 2.5.x or 2.6.x"; exit 1 ;;
 esac
 
 log() {

--- a/templates/smcp-templates/v2.6/cr_2.6_default_template.yaml
+++ b/templates/smcp-templates/v2.6/cr_2.6_default_template.yaml
@@ -1,0 +1,25 @@
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+metadata:
+  name: {{ .Name }}
+spec:
+  version: v2.6
+  tracing:
+    type: Jaeger
+    sampling: 10000
+  policy:
+    type: Istiod
+  addons:
+    grafana:
+      enabled: true
+    jaeger:
+      install:
+        storage:
+          type: Memory
+    kiali:
+      enabled: true
+    prometheus:
+      enabled: true
+  
+  telemetry:
+    type: Istiod


### PR DESCRIPTION
- Updated files to be able to work with 2.6.x version
- Bump GatewayAPI to v1.0.0 for SMCP 2.6