### PR TITLE
[OSSM-6732] Removed explicitly specified tracing type from SMCP files

### DIFF
--- a/pkg/tests/ossm/deploy_on_infra_test.go
+++ b/pkg/tests/ossm/deploy_on_infra_test.go
@@ -130,7 +130,10 @@ spec:
 			})
 
 			t.LogStep("Verify that the following control plane pods are running on the infra node: istiod, istio-ingressgateway, istio-egressgateway, jaeger, grafana, prometheus")
-			istioPodLabelSelectors := []string{"app=istiod", "app=istio-ingressgateway", "app=istio-egressgateway", "app=grafana", "app=prometheus", "app=jaeger"}
+			istioPodLabelSelectors := []string{"app=istiod", "app=istio-ingressgateway", "app=istio-egressgateway", "app=grafana", "app=prometheus"}
+			if env.GetSMCPVersion().LessThanOrEqual(version.SMCP_2_5) {
+				istioPodLabelSelectors = append(istioPodLabelSelectors, "app=jaeger")
+			}
 			for _, pLabel := range istioPodLabelSelectors {
 				assertPodScheduledToNode(t, pLabel)
 			}

--- a/pkg/tests/ossm/operator/clusterwide_mode_test.go
+++ b/pkg/tests/ossm/operator/clusterwide_mode_test.go
@@ -554,17 +554,12 @@ spec:
       componentLevels:
         default: info
   tracing:
-    type: Jaeger
     sampling: 10000
   policy:
     type: Istiod
   addons:
     grafana:
       enabled: true
-    jaeger:
-      install:
-        storage:
-          type: Memory
     kiali:
       enabled: true
     prometheus:

--- a/pkg/tests/ossm/route_prevent_additional_ingress_test.go
+++ b/pkg/tests/ossm/route_prevent_additional_ingress_test.go
@@ -81,7 +81,6 @@ metadata:
 spec: 
   version: {{ .Version }}
   tracing:
-    type: Jaeger
     sampling: 10000
   policy:
     type: Istiod

--- a/pkg/tests/ossm/smoke_test.go
+++ b/pkg/tests/ossm/smoke_test.go
@@ -201,9 +201,6 @@ func assertRoutesExist(t TestHelper) {
 			assert.OutputContains("istio-ingressgateway",
 				"Route istio-ingressgateway is created",
 				"Still waiting for route istio-ingressgateway to be created in namespace"),
-			assert.OutputContains("jaeger",
-				"Route jaeger is created",
-				"Still waiting for route jaeger to be created in namespace"),
 			assert.OutputContains("kiali",
 				"Route kiali is created",
 				"Still waiting for route kiali to be created in namespace"),
@@ -211,6 +208,18 @@ func assertRoutesExist(t TestHelper) {
 				"Route prometheus is created",
 				"Still waiting for route prometheus to be created in namespace"))
 	})
+
+	if env.GetSMCPVersion().LessThanOrEqual(version.SMCP_2_5) {
+		retry.UntilSuccess(t, func(t TestHelper) {
+			oc.Get(t,
+				meshNamespace,
+				"routes", "",
+				assert.OutputContains("jaeger",
+					"Route jaeger is created",
+					"Still waiting for route jaeger to be created in namespace"),
+			)
+		})
+	}
 }
 
 func getPreviousVersion(ver version.Version) version.Version {

--- a/pkg/tests/ossm/yaml/smcp.yaml
+++ b/pkg/tests/ossm/yaml/smcp.yaml
@@ -5,17 +5,12 @@ metadata:
 spec:
   version: {{ .Version }}
   tracing:
-    type: Jaeger
     sampling: 10000
   policy:
     type: Istiod
   addons:
     grafana:
       enabled: true
-    jaeger:
-      install:
-        storage:
-          type: Memory
     kiali:
       enabled: true
     prometheus:

--- a/templates/smcp-templates/v2.5/cr_2.5_default_template.yaml
+++ b/templates/smcp-templates/v2.5/cr_2.5_default_template.yaml
@@ -20,6 +20,5 @@ spec:
       enabled: true
     prometheus:
       enabled: true
-  
   telemetry:
     type: Istiod

--- a/templates/smcp-templates/v2.6/cr_2.6_default_template.yaml
+++ b/templates/smcp-templates/v2.6/cr_2.6_default_template.yaml
@@ -5,17 +5,12 @@ metadata:
 spec:
   version: v2.6
   tracing:
-    type: Jaeger
-    sampling: 10000
+    type: None
   policy:
     type: Istiod
   addons:
     grafana:
       enabled: true
-    jaeger:
-      install:
-        storage:
-          type: Memory
     kiali:
       enabled: true
     prometheus:


### PR DESCRIPTION
* Adapted tests to not check Jaeger on SMCP v2.6