### PR TITLE
[OSSM-6738] MTT:  GatewayAPI is enabled by default in ClusterWide mode

### DIFF
--- a/pkg/tests/ossm/operator/clusterwide_mode_test.go
+++ b/pkg/tests/ossm/operator/clusterwide_mode_test.go
@@ -105,6 +105,10 @@ func TestClusterWideMode(t *testing.T) {
 		})
 
 		t.NewSubTest("Deploy the Kubernetes Gateway API in ClusterWide mode").Run(func(t TestHelper) {
+			if env.GetSMCPVersion().LessThanOrEqual(version.SMCP_2_4) {
+				t.Skip("Deploy the Gateway API in ClusterWide mode failed for SMCP 2.4, https://issues.redhat.com/browse/OSSM-6765")
+			}
+
 			t.Cleanup(func() {
 				oc.RecreateNamespace(t, ns.Foo)
 			})


### PR DESCRIPTION
1. Added to TestClusterWideMode gateway API default state test (ClusterWide)
2. Added to TestGatewayApi gateway API default state test  (MultiTenant)
3. Added to TestClusterWideMode testcase Deploy_the_Kubernetes_Gateway_API from TestGatewayApi to test not only  on MultiTenant but also on ClusterWide

**SMCP_VERSION=2.5 TEST_CASE=TestClusterWideMode:**
```
=== RUN   TestClusterWideMode/check_Gateway_API_settings
    clusterwide_mode_test.go:67: Check Gateway API is disabled by default
    clusterwide_mode_test.go:69: Related issue: https://issues.redhat.com/browse/OSSM-6693
    clusterwide_mode_test.go:71:    
    clusterwide_mode_test.go:71: STEP 1: Check istiod deployment environment variables
    clusterwide_mode_test.go:88:    Env PILOT_ENABLE_GATEWAY_API is set to false
    clusterwide_mode_test.go:88:    Env PILOT_ENABLE_GATEWAY_API_STATUS is set to false
    clusterwide_mode_test.go:88:    Env PILOT_ENABLE_GATEWAY_API_DEPLOYMENT_CONTROLLER is set to false
    subtest.go:25: 
    subtest.go:32: Subtest completed in 0.68s (excluding cleanup)
=== RUN   TestClusterWideMode/Deploy_the_Kubernetes_Gateway_API_in_ClusterWide_mode
    clusterwide_mode_test.go:110:    
    clusterwide_mode_test.go:110: STEP 1: Install httpbin
    clusterwide_mode_test.go:111:    Install app "httpbin" in namespace "foo"
    clusterwide_mode_test.go:111:    Wait for app foo/httpbin to be ready
    clusterwide_mode_test.go:114:    
    clusterwide_mode_test.go:114: STEP 2: Enable the Gateway for SMCP < 2.6
    clusterwide_mode_test.go:127:    
    clusterwide_mode_test.go:127: STEP 3: Deploy the Gateway API configuration including a single exposed route (i.e., /get)
    clusterwide_mode_test.go:133:    
    clusterwide_mode_test.go:133: STEP 4: Wait for Gateway to be ready
    clusterwide_mode_test.go:134:    Wait for condition condition=Programmed on Gateway foo/gateway...
    clusterwide_mode_test.go:134:    SUCCESS: Condition condition=Programmed met by Gateway foo/gateway
    clusterwide_mode_test.go:136:    
    clusterwide_mode_test.go:136: STEP 5: Verfiy the GatewayApi access the httpbin service using curl
    clusterwide_mode_test.go:138:    SUCCESS: Access the httpbin service with GatewayApi
    subtest.go:25: 
    subtest.go:32: Subtest completed in 10.11s (excluding cleanup)
```

**SMCP_VERSION=2.5 TEST_CASE=TestGatewayApi:**
```
== RUN   TestGatewayApi/Check_default_Gateway_API_settings
    gatewayapi_test.go:44: Check Gateway API is disabled by default
    gatewayapi_test.go:46:    
    gatewayapi_test.go:46: STEP 1: Check istiod deployment environment variables
    gatewayapi_test.go:63:    Env PILOT_ENABLE_GATEWAY_API is set to false
    gatewayapi_test.go:63:    Env PILOT_ENABLE_GATEWAY_API_STATUS is set to false
    gatewayapi_test.go:63:    Env PILOT_ENABLE_GATEWAY_API_DEPLOYMENT_CONTROLLER is set to false
    subtest.go:25: 
    subtest.go:32: Subtest completed in 1.15s (excluding cleanup)
```

**SMCP_VERSION=2.6 TEST_CASE=TestClusterWideMode:**
```
=== RUN   TestClusterWideMode/check_Gateway_API_settings
    clusterwide_mode_test.go:65: Check Gateway API is enabled by default for SMCP >= 2.6
    clusterwide_mode_test.go:69: Related issue: https://issues.redhat.com/browse/OSSM-6693
    clusterwide_mode_test.go:71:    
    clusterwide_mode_test.go:71: STEP 1: Check istiod deployment environment variables
    clusterwide_mode_test.go:100:    All variables were checked, PILOT_ENABLE_GATEWAY_API variables were not detected
    subtest.go:25: 
    subtest.go:32: Subtest completed in 1.00s (excluding cleanup)
=== RUN   TestClusterWideMode/Deploy_the_Kubernetes_Gateway_API_in_ClusterWide_mode
    clusterwide_mode_test.go:110:    
    clusterwide_mode_test.go:110: STEP 1: Install httpbin
    clusterwide_mode_test.go:111:    Install app "httpbin" in namespace "foo"
    clusterwide_mode_test.go:111:    Wait for app foo/httpbin to be ready
    clusterwide_mode_test.go:127:    
    clusterwide_mode_test.go:127: STEP 2: Deploy the Gateway API configuration including a single exposed route (i.e., /get)
    clusterwide_mode_test.go:133:    
    clusterwide_mode_test.go:133: STEP 3: Wait for Gateway to be ready
    clusterwide_mode_test.go:134:    Wait for condition condition=Programmed on Gateway foo/gateway...
    clusterwide_mode_test.go:134:    SUCCESS: Condition condition=Programmed met by Gateway foo/gateway
    clusterwide_mode_test.go:136:    
    clusterwide_mode_test.go:136: STEP 4: Verfiy the GatewayApi access the httpbin service using curl
    clusterwide_mode_test.go:138:    SUCCESS: Access the httpbin service with GatewayApi
    subtest.go:25: 
    subtest.go:32: Subtest completed in 11.15s (excluding cleanup)
```

**SMCP_VERSION=2.6 TEST_CASE=TestGatewayApi:** 
```
=== RUN   TestGatewayApi/Check_default_Gateway_API_settings
    gatewayapi_test.go:44: Check Gateway API is disabled by default
    gatewayapi_test.go:46:    
    gatewayapi_test.go:46: STEP 1: Check istiod deployment environment variables
    gatewayapi_test.go:63:    Env PILOT_ENABLE_GATEWAY_API is set to false
    gatewayapi_test.go:63:    Env PILOT_ENABLE_GATEWAY_API_STATUS is set to false
    gatewayapi_test.go:63:    Env PILOT_ENABLE_GATEWAY_API_DEPLOYMENT_CONTROLLER is set to false
    subtest.go:25: 
    subtest.go:32: Subtest completed in 0.70s (excluding cleanup)
```

Related:

- https://issues.redhat.com/browse/OSSM-6738
- https://issues.redhat.com/browse/OSSM-6693