### PR TITLE
[OSSM-6737] Verify that Jaeger is not created by default

### DIFF
--- a/pkg/util/oc/oc.go
+++ b/pkg/util/oc/oc.go
@@ -262,9 +262,9 @@ func GetYaml(t test.TestHelper, ns, kind, name string, checks ...common.CheckFun
 }
 
 // GetJson returns the JSON representation of the resource, you can set a jsonPath to extract a specific value or send "" to get the full JSON
-func GetJson(t test.TestHelper, ns, kind, name string, jsonPath string) string {
+func GetJson(t test.TestHelper, ns, kind, name string, jsonPath string, checks ...common.CheckFunc) string {
 	t.T().Helper()
-	return DefaultOC.GetJson(t, ns, kind, name, jsonPath)
+	return DefaultOC.GetJson(t, ns, kind, name, jsonPath, checks...)
 }
 
 func GetProxy(t test.TestHelper) *Proxy {

--- a/pkg/util/oc/oc_struct.go
+++ b/pkg/util/oc/oc_struct.go
@@ -434,16 +434,16 @@ func (o OC) GetYaml(t test.TestHelper, ns, kind, name string, checks ...common.C
 	return val
 }
 
-func (o OC) GetJson(t test.TestHelper, ns, kind, name, jsonPath string) string {
+func (o OC) GetJson(t test.TestHelper, ns, kind, name, jsonPath string, checks ...common.CheckFunc) string {
 	t.T().Helper()
 	var jsonString string
 	o.withKubeconfig(t, func() {
 		t.T().Helper()
 		if jsonPath == "" {
-			jsonString = shell.Execute(t, fmt.Sprintf(`oc %s get %s %s -o json`, nsFlag(ns), kind, name))
+			jsonString = shell.Execute(t, fmt.Sprintf(`oc %s get %s %s -o json`, nsFlag(ns), kind, name), checks...)
 		} else {
 			jsonPath = strings.ReplaceAll(jsonPath, "'", `'"'"'`)
-			jsonString = shell.Execute(t, fmt.Sprintf(`oc %s get %s %s -o jsonpath='%s'`, nsFlag(ns), kind, name, jsonPath))
+			jsonString = shell.Execute(t, fmt.Sprintf(`oc %s get %s %s -o jsonpath='%s'`, nsFlag(ns), kind, name, jsonPath), checks...)
 		}
 	})
 	return jsonString


### PR DESCRIPTION
Added check of Jaeger's not-existence and SMCP tracing settings for smcp 2.6+

```
    smoke_test.go:154: STEP 8: Verify Jaeger and SMCP tracing settings
    smoke_test.go:155:    Related issue: https://issues.redhat.com/browse/OSSM-6391
    smoke_test.go:157:    Verify SMCP tracing settings
    smoke_test.go:158:    SUCCESS: smcp .status.appliedValues.istio.tracing.enabled is false
    smoke_test.go:167:    SUCCESS: smcp .status.appliedValues.istio.tracing.provider is none
    smoke_test.go:177:    Verify that Jaeger resources (Route, Deployment, and Pod) were not created
    smoke_test.go:178:    SUCCESS: Jaeger resources (pod, deployment, route) were not found
```

Extended oc.GetJson function with checks 

Related:
- https://issues.redhat.com/browse/OSSM-6737
- https://issues.redhat.com/browse/OSSM-6391
- https://github.com/maistra/istio-operator/pull/1802