### PR TITLE
[OSSM-6739] Add test case for CNI resources prune

### DIFF
--- a/pkg/util/cni/cni.go
+++ b/pkg/util/cni/cni.go
@@ -1,0 +1,39 @@
+package cni
+
+import "github.com/maistra/maistra-test-tool/pkg/util/version"
+
+type Resource struct {
+	Obj            string
+	Name           string
+	UsedInVersions []version.Version
+}
+
+// Resources source: https://github.com/maistra/istio-operator/blob/maistra-2.6/pkg/controller/servicemesh/controlplane/cni_pruner.go
+var CniResources = []Resource{
+	toResource("ClusterRole", "istio-cni", version.SMCP_2_0, version.SMCP_2_1, version.SMCP_2_2, version.SMCP_2_3),
+	toResource("ClusterRole", "ossm-cni", version.SMCP_2_4, version.SMCP_2_5, version.SMCP_2_6),
+	toResource("ClusterRoleBinding", "istio-cni", version.SMCP_2_0, version.SMCP_2_1, version.SMCP_2_2, version.SMCP_2_3),
+	toResource("ClusterRoleBinding", "ossm-cni", version.SMCP_2_4, version.SMCP_2_5, version.SMCP_2_6),
+	toResource("ConfigMap", "istio-cni-config", version.SMCP_2_0, version.SMCP_2_1, version.SMCP_2_2),
+	toResource("ConfigMap", "istio-cni-config-v2-3", version.SMCP_2_3),
+	toResource("ConfigMap", "ossm-cni-config-v2-4", version.SMCP_2_4),
+	toResource("ConfigMap", "ossm-cni-config-v2-5", version.SMCP_2_5),
+	toResource("ConfigMap", "ossm-cni-config-v2-6", version.SMCP_2_6),
+	toResource("DaemonSet", "istio-cni-node", version.SMCP_2_0, version.SMCP_2_1, version.SMCP_2_2),
+	toResource("DaemonSet", "istio-cni-node-v2-3", version.SMCP_2_3),
+	toResource("DaemonSet", "istio-cni-node-v2-4", version.SMCP_2_4),
+	toResource("DaemonSet", "istio-cni-node-v2-5", version.SMCP_2_5),
+	toResource("DaemonSet", "istio-cni-node-v2-6", version.SMCP_2_6),
+	toResource("ServiceAccount", "istio-cni", version.SMCP_2_0, version.SMCP_2_1, version.SMCP_2_2, version.SMCP_2_3),
+	toResource("ServiceAccount", "ossm-cni", version.SMCP_2_4, version.SMCP_2_5, version.SMCP_2_6),
+}
+
+func toResource(obj string, name string, versions ...version.Version) Resource {
+	r := Resource{
+		Obj:  obj,
+		Name: name,
+	}
+	r.UsedInVersions = append(r.UsedInVersions, versions...)
+
+	return r
+}

--- a/pkg/util/compare.go
+++ b/pkg/util/compare.go
@@ -69,3 +69,13 @@ func CompareToFile(out []byte, modelFile string) error {
 	}
 	return Compare(out, model)
 }
+
+// Contains checks if a slice contains an element
+func Contains[T comparable](s []T, e T) bool {
+	for _, v := range s {
+		if v == e {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Integrated CNI prune/preserve checks in smoke upgrade/delete tests

**TEST_CASE=TestSmoke**
**Upgrade**
```
=== RUN   TestSmoke/upgrade_v2.3_to_v2.4
    ...
    smoke_test.go:88: STEP 14: Check that previous version CNI resources were pruned and needed resources were preserved
    smoke_test.go:259:    SUCCESS: Resource ClusterRole/istio-cni was pruned
    smoke_test.go:250:    SUCCESS: Resource ClusterRole/ossm-cni was preserved
    smoke_test.go:259:    SUCCESS: Resource ClusterRoleBinding/istio-cni was pruned
    smoke_test.go:250:    SUCCESS: Resource ClusterRoleBinding/ossm-cni was preserved
    smoke_test.go:259:    SUCCESS: Resource ConfigMap/istio-cni-config-v2-3 was pruned
    smoke_test.go:250:    SUCCESS: Resource ConfigMap/ossm-cni-config-v2-4 was preserved
    smoke_test.go:259:    SUCCESS: Resource DaemonSet/istio-cni-node-v2-3 was pruned
    smoke_test.go:250:    SUCCESS: Resource DaemonSet/istio-cni-node-v2-4 was preserved
    smoke_test.go:259:    SUCCESS: Resource ServiceAccount/istio-cni was pruned
    smoke_test.go:250:    SUCCESS: Resource ServiceAccount/ossm-cni was preserved
    ...
```

```
=== RUN   TestSmoke/upgrade_v2.4_to_v2.5
    ...
    smoke_test.go:88: STEP 14: Check that previous version CNI resources were pruned and needed resources were preserved
    smoke_test.go:250:    SUCCESS: Resource ClusterRole/ossm-cni was preserved
    smoke_test.go:250:    SUCCESS: Resource ClusterRoleBinding/ossm-cni was preserved
    smoke_test.go:259:    SUCCESS: Resource ConfigMap/ossm-cni-config-v2-4 was pruned
    smoke_test.go:250:    SUCCESS: Resource ConfigMap/ossm-cni-config-v2-5 was preserved
    smoke_test.go:259:    SUCCESS: Resource DaemonSet/istio-cni-node-v2-4 was pruned
    smoke_test.go:250:    SUCCESS: Resource DaemonSet/istio-cni-node-v2-5 was preserved
    smoke_test.go:250:    SUCCESS: Resource ServiceAccount/ossm-cni was preserved
    ...
```

```
=== RUN   TestSmoke/upgrade_v2.5_to_v2.6
    ...
    smoke_test.go:88: STEP 14: Check that previous version CNI resources were pruned and needed resources were preserved
    smoke_test.go:250:    SUCCESS: Resource ClusterRole/ossm-cni was preserved
    smoke_test.go:250:    SUCCESS: Resource ClusterRoleBinding/ossm-cni was preserved 
    smoke_test.go:259:    SUCCESS: Resource ConfigMap/ossm-cni-config-v2-5 was pruned 
    smoke_test.go:250:    SUCCESS: Resource ConfigMap/ossm-cni-config-v2-6 was preserved
    smoke_test.go:259:    SUCCESS: Resource DaemonSet/istio-cni-node-v2-5 was pruned
    smoke_test.go:250:    SUCCESS: Resource DaemonSet/istio-cni-node-v2-6 was preserved
    smoke_test.go:250:    SUCCESS: Resource ServiceAccount/ossm-cni was preserved
    ...
```

**Delete**:
```
=== RUN   TestSmoke/delete_smcp_v2.4
    ...
    smoke_test.go:126: STEP 3: Check that CNI resources were pruned
    smoke_test.go:275:    SUCCESS: Resource ClusterRole/ossm-cni was pruned
    smoke_test.go:275:    SUCCESS: Resource ClusterRoleBinding/ossm-cni was pruned
    smoke_test.go:275:    SUCCESS: Resource ConfigMap/ossm-cni-config-v2-4 was pruned
    smoke_test.go:275:    SUCCESS: Resource DaemonSet/istio-cni-node-v2-4 was pruned
    smoke_test.go:275:    SUCCESS: Resource ServiceAccount/ossm-cni was pruned
    ...
```

```
=== RUN   TestSmoke/delete_smcp_v2.5
    ...
    smoke_test.go:126: STEP 3: Check that CNI resources were pruned
    smoke_test.go:275:    SUCCESS: Resource ClusterRole/ossm-cni was pruned
    smoke_test.go:275:    SUCCESS: Resource ClusterRoleBinding/ossm-cni was pruned
    smoke_test.go:275:    SUCCESS: Resource ConfigMap/ossm-cni-config-v2-5 was pruned
    smoke_test.go:275:    SUCCESS: Resource DaemonSet/istio-cni-node-v2-5 was pruned
    smoke_test.go:275:    SUCCESS: Resource ServiceAccount/ossm-cni was pruned
    ...
```

```
=== RUN   TestSmoke/delete_smcp_v2.6
    ...
    smoke_test.go:126: STEP 3: Check that CNI resources were pruned
    smoke_test.go:275:    SUCCESS: Resource ClusterRole/ossm-cni was pruned
    smoke_test.go:275:    SUCCESS: Resource ClusterRoleBinding/ossm-cni was pruned
    smoke_test.go:275:    SUCCESS: Resource ConfigMap/ossm-cni-config-v2-6 was pruned
    smoke_test.go:275:    SUCCESS: Resource DaemonSet/istio-cni-node-v2-6 was pruned
    smoke_test.go:275:    SUCCESS: Resource ServiceAccount/ossm-cni was pruned
    ...
```

Related:

- https://issues.redhat.com/browse/OSSM-6739
- https://issues.redhat.com/browse/OSSM-2101
- https://github.com/maistra/istio-operator/pull/1816