### PR TITLE
[OSSM-6761] Use the correct Operator version (not SMCP version)

### DIFF
--- a/pkg/tests/ossm/smm_test.go
+++ b/pkg/tests/ossm/smm_test.go
@@ -89,8 +89,8 @@ func TestSMMReconciliation(t *testing.T) {
 		t.Log("This test verifies whether the member-of label is added back to the namespace")
 		t.Log("See https://issues.redhat.com/browse/OSSM-1397")
 
-		if !env.GetSMCPVersion().Equals(env.GetOperatorVersion()) {
-			t.Skip("Skipped because This test case is only needed to be tested when the SMCP version is the latest version available in the Operator")
+		if !(env.GetSMCPVersion().Equals(env.GetOperatorVersion())) {
+			t.Skipf("Skipped because This test case is only needed to be tested when the SMCP version is the latest version available in the Operator. Operator version: %s SMCP version: %s", env.GetOperatorVersion(), env.GetSMCPVersion())
 		}
 
 		t.Cleanup(func() {

--- a/pkg/tests/ossm/smoke_test.go
+++ b/pkg/tests/ossm/smoke_test.go
@@ -84,10 +84,11 @@ func TestSmoke(t *testing.T) {
 			oc.RestartAllPodsAndWaitReady(t, ns)
 
 			checkSMCP(t, ns)
-
-			t.LogStep("Check that previous version CNI resources were pruned and needed resources were preserved")
-			t.Log("Related issue: https://issues.redhat.com/browse/OSSM-2101")
-			assertResourcesPruneUpgrade(t, fromVersion, toVersion)
+			if env.GetOperatorVersion().GreaterThanOrEqual(version.OPERATOR_2_6_0) {
+				t.LogStep("Check that previous version CNI resources were pruned and needed resources were preserved")
+				t.Log("Related issue: https://issues.redhat.com/browse/OSSM-2101")
+				assertResourcesPruneUpgrade(t, fromVersion, toVersion)
+			}
 		})
 
 		t.NewSubTest(fmt.Sprintf("install smcp %s", toVersion)).Run(func(t TestHelper) {
@@ -123,10 +124,11 @@ func TestSmoke(t *testing.T) {
 						"SMCP resources are deleted",
 						"Still waiting for resources to be deleted from namespace"))
 			})
-
-			t.LogStep("Check that CNI resources were pruned")
-			t.Log("Related issue: https://issues.redhat.com/browse/OSSM-2101")
-			assertResourcePruneDelete(t, toVersion)
+			if env.GetOperatorVersion().GreaterThanOrEqual(version.OPERATOR_2_6_0) {
+				t.LogStep("Check that CNI resources were pruned")
+				t.Log("Related issue: https://issues.redhat.com/browse/OSSM-2101")
+				assertResourcePruneDelete(t, toVersion)
+			}
 		})
 
 	})

--- a/pkg/util/env/env.go
+++ b/pkg/util/env/env.go
@@ -54,7 +54,7 @@ func GetSMCPVersion() version.Version {
 }
 
 func GetOperatorVersion() version.Version {
-	return version.ParseVersion(getenv("OPERATOR_VERSION", "v2.6"))
+	return version.ParseVersion(getenv("OPERATOR_VERSION", "2.6.0"))
 }
 
 func GetArch() string {

--- a/pkg/util/version/operator_version.go
+++ b/pkg/util/version/operator_version.go
@@ -1,0 +1,6 @@
+package version
+
+var (
+	OPERATOR_2_5_2 = ParseVersion("2.5.2")
+	OPERATOR_2_6_0 = ParseVersion("2.6.0")
+)

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -169,7 +169,7 @@ main() {
 
     if [ -z "$SMCP_VERSION" ]; then
         for ver in "${SUPPORTED_VERSIONS[@]}"; do
-            export OPERATOR_VERSION="$ver"
+            export OPERATOR_VERSION="$OPERATOR_VERSION"
             export SMCP_VERSION="$ver"
             export OUTPUT_DIR="${OUTPUT_DIR_BASE}/${SMCP_VERSION}"  # also used in env.GetOutputDir(), so must be exported
             export LOG_FILE="$OUTPUT_DIR/output.log"


### PR DESCRIPTION
* Use Operator version env to determine against which operator the tests are running

Right now, the SMCP version is used for Operator version ( which is not the same )