### PR TITLE
[OSSM-6759] Bump ubi version in test container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 ARG HELM_VERSION="v3.11.3"
 ARG GO_VERSION="1.20.3"
+ARG OCP_VERSION="stable"
 
 ENV GOPATH=/go
 ENV PATH=/usr/local/go/bin:$GOPATH/bin:$PATH
 # we need to set HOME when running on OCP with random UID, otherwise the home is set to / and any writing there will fail with permission denied
 ENV HOME=$GOPATH/src/maistra-test-tool
 
-RUN microdnf install --nodocs tar gzip openssl findutils make git && \
-    curl -Lo ./oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz && \
+RUN microdnf install -y --nodocs tar gzip openssl findutils make git && \
+    curl -Lo ./oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OCP_VERSION}/openshift-client-linux.tar.gz && \
     tar -xf oc.tar.gz -C /usr/bin && \
     rm -f oc.tar.gz && \
     curl -Lo ./golang.tar.gz https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz && \


### PR DESCRIPTION
fix for:
```
oc: /lib64/libc.so.6: version `GLIBC_2.33' not found (required by oc)
oc: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by oc)
oc: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by oc)
```
Due to a new oc binary which needs rhel9 (there is also rhel8 variant)