### PR TITLE
Update certmanageroperator to get version dynamicly

### DIFF
--- a/pkg/util/operator/operators.go
+++ b/pkg/util/operator/operators.go
@@ -17,6 +17,16 @@ func GetCsvName(t test.TestHelper, operatorNamespace string, partialName string)
 	return strings.TrimSpace(output)
 }
 
+func WaitForCsvReady(t test.TestHelper, partialName string) {
+	t.Logf("Waiting for csv %s is ready", partialName)
+	retry.UntilSuccessWithOptions(t, retry.Options().DelayBetweenAttempts(1*time.Second).MaxAttempts(20), func(t test.TestHelper) {
+		output := shell.Execute(t, fmt.Sprintf(`oc get csv -A -o custom-columns="NAME:.metadata.name" |grep %s ||true`, partialName))
+		if output == "" {
+			t.Errorf("CSV %s is not ready yet", partialName)
+		}
+	})
+}
+
 func OperatorExists(t test.TestHelper, csvVersion string) bool {
 	output := shell.Execute(t, fmt.Sprintf(`oc get csv -A -o custom-columns="NAME:.metadata.name,REPLACES:.spec.replaces" |grep %s ||true`, csvVersion))
 	return strings.Contains(output, csvVersion)


### PR DESCRIPTION
Right now, we need to update certmanageroperator version every time it is updated. 
However, we are using `startingCSV:` in the subscription so we don't need to know what is the latest version, the olm downloads the latest one. 

So we can find it out dynamically and there is no need to update the certmanageroperatorversion anymore.