### PR TITLE
Hotfix for installing certmanageroperator

### DIFF
--- a/pkg/certmanageroperator/install.go
+++ b/pkg/certmanageroperator/install.go
@@ -60,7 +60,8 @@ func installOperator(t test.TestHelper) {
 }
 
 func waitOperatorSucceded(t test.TestHelper) {
-	fullCsvName := operator.GetCsvName(t, certManagerOperatorNs, certManagerCSVName)
-	operator.WaitForOperatorReady(t, certManagerOperatorNs, "name="+certManagerCSVName, fullCsvName)
+	// waiting for operator
+	oc.WaitPodReadyWithOptions(t, retry.Options().MaxAttempts(70).DelayBetweenAttempts(5*time.Second), pod.MatchingSelector("name="+certManagerCSVName, certManagerOperatorNs))
+	// waiting for control plane
 	oc.WaitPodReadyWithOptions(t, retry.Options().MaxAttempts(70).DelayBetweenAttempts(5*time.Second), pod.MatchingSelector("app=cert-manager", certManagerNs))
 }


### PR DESCRIPTION
getCsvName can returns more names when it is running during upgrading the version from minVersion specified in the subscription to the latest released version. New way is more simplest