### PR TITLE
OSSM-6817: Update TestMustGather with new must-gather container

### DIFF
--- a/pkg/tests/ossm/smcp_must_gather_test.go
+++ b/pkg/tests/ossm/smcp_must_gather_test.go
@@ -123,15 +123,25 @@ func TestMustGather(t *testing.T) {
 				assertFilesExist(t,
 					dir,
 					"**/cluster-scoped-resources/rbac.authorization.k8s.io/clusterrolebindings/istiod-internal-basic-istio-system.yaml",
-					//TODO uncomment when we resolve whether the olm created resources must be in must-gather imaga
-					// "**/cluster-scoped-resources/admissionregistration.k8s.io/mutatingwebhookconfigurations/smcp.validation.maistra.io-*.yaml",
-					// "**/cluster-scoped-resources/admissionregistration.k8s.io/mutatingwebhookconfigurations/smmr.validation.maistra.io-*.yaml",
 					"**/cluster-scoped-resources/admissionregistration.k8s.io/mutatingwebhookconfigurations/istiod-basic-istio-system.yaml",
-					// "**/cluster-scoped-resources/admissionregistration.k8s.io/validatingwebhookconfigurations/smcp.validation.maistra.io-*.yaml",
-					// "**/cluster-scoped-resources/admissionregistration.k8s.io/validatingwebhookconfigurations/smmr.validation.maistra.io-*.yaml",
-					// "**/cluster-scoped-resources/admissionregistration.k8s.io/validatingwebhookconfigurations/smm.validation.maistra.io-*.yaml",
 					"**/cluster-scoped-resources/admissionregistration.k8s.io/validatingwebhookconfigurations/istio-validator-basic-istio-system.yaml",
 					"**/cluster-scoped-resources/rbac.authorization.k8s.io/clusterroles/istiod-clusterrole-basic-istio-system.yaml")
+
+				webhookMap := map[string]string{
+					"smcp.mutation.maistra.io":   "mutatingwebhookconfigurations",
+					"smmr.mutation.maistra.io":   "mutatingwebhookconfigurations",
+					"smcp.validation.maistra.io": "validatingwebhookconfigurations",
+					"smmr.validation.maistra.io": "validatingwebhookconfigurations",
+					"smm.validation.maistra.io":  "validatingwebhookconfigurations",
+				}
+
+				for webhook, kind := range webhookMap {
+					name := oc.GetResouceNameByLabel(t, "", kind, fmt.Sprintf("olm.webhook-description-generate-name=%s", webhook))
+					filename := fmt.Sprintf("%s.yaml", name)
+					assertFilesExist(t,
+						dir,
+						fmt.Sprintf("**/cluster-scoped-resources/admissionregistration.k8s.io/%s/%s", kind, filename))
+				}
 			}
 		})
 

--- a/pkg/util/env/env.go
+++ b/pkg/util/env/env.go
@@ -66,11 +66,19 @@ func GetTestGroup() string {
 }
 
 func GetMustGatherImage() string {
-	return "registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel8:" + GetMustGatherTag()
+	operatorVersion := GetOperatorVersion()
+	if operatorVersion.LessThan(version.OPERATOR_2_6_0) {
+		return "registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel8:" + GetMustGatherTag()
+	} else {
+		// https://issues.redhat.com/browse/OSSM-6818
+		// TODO: Potentially can be updated with brew registries or after release with redhat registries
+		// Now using quay image built with https://github.com/maistra/istio-must-gather/pull/29
+		return "quay.io/maistra/istio-must-gather:2.6.0"
+	}
 }
 
 func GetMustGatherTag() string {
-	return getenv("MUST_GATHER_TAG", "2.4")
+	return getenv("MUST_GATHER_TAG", fmt.Sprintf("%d.%d", GetOperatorVersion().Major, GetOperatorVersion().Minor))
 }
 
 func IsMustGatherEnabled() bool {


### PR DESCRIPTION
1. Use must gather 2.5 for ossm 2.5 (use in general must gather based on operator version)
2. Check new webhooks for 2.6
```
    smcp_must_gather_test.go:112: STEP 3: Verify cluster-scoped-resources files exist in cluster-scoped-resources folder
    smcp_must_gather_test.go:182:    SUCCESS: /tmp/must-gather-1670015299/**/cluster-scoped-resources/rbac.authorization.k8s.io/clusterrolebindings/istiod-internal-basic-istio-system.yaml exists
    smcp_must_gather_test.go:182:    SUCCESS: /tmp/must-gather-1670015299/**/cluster-scoped-resources/admissionregistration.k8s.io/mutatingwebhookconfigurations/istiod-basic-istio-system.yaml exists
    smcp_must_gather_test.go:182:    SUCCESS: /tmp/must-gather-1670015299/**/cluster-scoped-resources/admissionregistration.k8s.io/validatingwebhookconfigurations/istio-validator-basic-istio-system.yaml exists
    smcp_must_gather_test.go:182:    SUCCESS: /tmp/must-gather-1670015299/**/cluster-scoped-resources/rbac.authorization.k8s.io/clusterroles/istiod-clusterrole-basic-istio-system.yaml exists
    smcp_must_gather_test.go:182:    SUCCESS: /tmp/must-gather-1670015299/**/cluster-scoped-resources/admissionregistration.k8s.io/validatingwebhookconfigurations/smmr.validation.maistra.io-nbnmn.yaml exists
    smcp_must_gather_test.go:182:    SUCCESS: /tmp/must-gather-1670015299/**/cluster-scoped-resources/admissionregistration.k8s.io/validatingwebhookconfigurations/smm.validation.maistra.io-4lct9.yaml exists
    smcp_must_gather_test.go:182:    SUCCESS: /tmp/must-gather-1670015299/**/cluster-scoped-resources/admissionregistration.k8s.io/mutatingwebhookconfigurations/smcp.mutation.maistra.io-2c7wr.yaml exists
    smcp_must_gather_test.go:182:    SUCCESS: /tmp/must-gather-1670015299/**/cluster-scoped-resources/admissionregistration.k8s.io/mutatingwebhookconfigurations/smmr.mutation.maistra.io-lqjdn.yaml exists
    smcp_must_gather_test.go:182:    SUCCESS: /tmp/must-gather-1670015299/**/cluster-scoped-resources/admissionregistration.k8s.io/validatingwebhookconfigurations/smcp.validation.maistra.io-jm4x4.yaml exists
```

Related:

1. https://issues.redhat.com/browse/OSSM-6817
3. https://github.com/maistra/maistra-test-tool/pull/708
4. https://github.com/maistra/istio-operator/commit/a33d372e098dc22319da45f7da4002cdba7252ee
5. (Not blocked but no reason to use without) https://github.com/maistra/istio-must-gather/pull/29
6. Jenkins mtt run 2224 (2.6) :green_circle:  and 2223 (2.5)  :green_circle: 