### PR TITLE
Add new error message to notify that connection between product-details doesn't work

### DIFF
--- a/pkg/tests/tasks/traffic/traffic_shifting_test.go
+++ b/pkg/tests/tasks/traffic/traffic_shifting_test.go
@@ -18,6 +18,7 @@ import (
 	_ "embed"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -108,6 +109,9 @@ func checkTrafficRatio(t TestHelper, url string, numberOfRequests int, tolerance
 					// }
 					matchedFile := app.FindBookinfoProductPageResponseFile(responseBody)
 					if matchedFile == "" {
+						if strings.Contains(string(responseBody), "Error fetching product details!") {
+							t.Fatal("The product page doesn't have information about product details. It can indicate a problem with the connection between product-details pod!")
+						}
 						t.Fatal("Response did not match any expected value and also didn't match any standard bookinfo productpage responses")
 					} else {
 						t.Fatalf("Response did not match any expected value, but matched file %q", matchedFile)


### PR DESCRIPTION
Separate error messages when the product page is not fully loaded ( for issues such ashttps://issues.redhat.com/browse/OSSM-6809 ) since `Response did not match any expected value and also didn't match any standard bookinfo productpage responses` is too general