### PR TITLE
OSSM-6817: Update 2.6.0 must-gather container source

### DIFF
--- a/pkg/util/env/env.go
+++ b/pkg/util/env/env.go
@@ -71,9 +71,8 @@ func GetMustGatherImage() string {
 		return "registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel8:" + GetMustGatherTag()
 	} else {
 		// https://issues.redhat.com/browse/OSSM-6818
-		// TODO: Potentially can be updated with brew registries or after release with redhat registries
-		// Now using quay image built with https://github.com/maistra/istio-must-gather/pull/29
-		return "quay.io/maistra/istio-must-gather:2.6.0"
+		// TODO: Else conditional should be errased after 2.6.0 release
+		return "brew.registry.redhat.io/rh-osbs/openshift-service-mesh-istio-must-gather-rhel8:2.6.0"
 	}
 }
 


### PR DESCRIPTION
Update 2.6.0 must-gather container source from **quay** to latest build in **registry-proxy.engineering.redhat**

*Still needed to update after release

Related:
1. https://issues.redhat.com/browse/OSSM-6817
3. https://github.com/maistra/maistra-test-tool/pull/708
4. https://github.com/maistra/istio-operator/commit/a33d372e098dc22319da45f7da4002cdba7252ee
5. https://github.com/maistra/istio-must-gather/pull/29
6. https://github.com/maistra/maistra-test-tool/pull/709
7. Jenkins mtt run 2264 :green_circle: