### PR TITLE
OSSM-6930: Resolve certmanager conflict for IBM Z&P

### DIFF
--- a/pkg/tests/tasks/security/certmanager/plugin_ca_test.go
+++ b/pkg/tests/tasks/security/certmanager/plugin_ca_test.go
@@ -33,9 +33,6 @@ func TestPluginCaCert(t *testing.T) {
 		if ocpVersion.LessThan(version.OCP_4_12) {
 			t.Skip("istio-csr is not supported in OCP older than v4.12")
 		}
-		if env.GetArch() == "z" || env.GetArch() == "p" {
-			t.Skip("istio-csr is not supported for IBM Z&P")
-		}
 
 		meshValues := map[string]interface{}{
 			"Name":    smcpName,

--- a/pkg/tests/tasks/security/certmanager/yaml/istio-csr/istio-csr.yaml
+++ b/pkg/tests/tasks/security/certmanager/yaml/istio-csr/istio-csr.yaml
@@ -2,8 +2,7 @@ replicaCount: 2
 
 image:
   repository: quay.io/jetstack/cert-manager-istio-csr
-  tag: v0.6.0
-  pullSecretName: ""
+  tag: v0.10.0
 
 app:
   certmanager:


### PR DESCRIPTION
Related:
- Cert-Manager test case failing for IBM Z ([OSSM-6930](https://issues.redhat.com/browse/OSSM-6930))

**TestIstioCsr**:
- Jenkins mtt run 2492  (P): :green_circle: 
- Jenkins mtt run 2494 (Z): :green_circle: 
- Jenkins mtt run 2490 (x86): :green_circle: (just to check that nothing is broken)

**TestPluginCaCert**:
- Jenkins mtt run 2502  (P): :green_circle: 
- Jenkins mtt run 2495  (Z): :green_circle: 
- Jenkins mtt run 2497  (x86): :green_circle:  (just to check that nothing is broken)

~~As it was it is still flaky need to open issue on that flakiness ...~~

Hope I was able to reduce flakiness a bit...