### PR TITLE
Add new test verifying helm charts versions

### DIFF
--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -31,6 +31,13 @@ runTestsAgainstVersion() {
         exit 1
     fi
 
+    EXPECTED_VERSIONS=""
+    for version in "$EXPECTED_VERSIONS[@]"; do
+        if[[ "$version" == "$SMCP_VERSION"* ]]; then
+            export EXPECTED_VERSION="$version"
+        fi
+    done
+
     echo "Output dir: $OUTPUT_DIR"
     mkdir -p "$OUTPUT_DIR"
 


### PR DESCRIPTION
We need to be sure that  the charts packaged within the operator image are from the correct release (we need to check the `maistra-version` label in those charts and that the charts themselves are in sync with the 2.3 and 2.2 branches)

Jira link [https://issues.redhat.com/browse/OSSM-5291](url)