### PR TITLE
OSSM-7992: Add test SMCP log levels

### DIFF
--- a/pkg/tests/ossm/smcp_logging_test.go
+++ b/pkg/tests/ossm/smcp_logging_test.go
@@ -1,0 +1,89 @@
+// Copyright Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ossm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/maistra/maistra-test-tool/pkg/util/check/assert"
+	"github.com/maistra/maistra-test-tool/pkg/util/oc"
+	"github.com/maistra/maistra-test-tool/pkg/util/shell"
+	. "github.com/maistra/maistra-test-tool/pkg/util/test"
+)
+
+func TestLogging(t *testing.T) {
+	NewTest(t).Groups(Full, Disconnected, ARM).Run(func(t TestHelper) {
+		t.Log("This test verifies allowed logging levels for the control plane")
+		t.Log("See https://issues.redhat.com/browse/OSSM-6331")
+
+		t.LogStep("Deploy control plane")
+		DeployControlPlane(t)
+
+		t.Cleanup(func() {
+			oc.Patch(t, meshNamespace, "smcp", smcpName, "merge", loggingDefaut)
+		})
+
+		t.LogStep("Try to patch SMCP with unsupported log levels (trace, critical), patch should fail")
+		shell.Execute(t,
+			fmt.Sprintf("oc patch smcp/%s -n %s --type merge --patch '%s' || true", smcpName, meshNamespace, errorLoggingComponentLevelsSMCP),
+			assert.OutputContains(`Error from server (BadRequest): admission webhook "smcp.validation.maistra.io" denied the request: [istiod doesn't support 'trace' log level, istiod doesn't support 'critical' log level]`,
+				"Patch failed as expected due to unsupported log levels",
+				"Patch succeeded unexpectedly, unsupported log levels were not rejected"))
+
+		t.LogStep("Wait SMCP ready")
+		oc.WaitSMCPReady(t, meshNamespace, smcpName)
+
+		t.LogStep("Try to patch SMCP with supported log levels (none, error, warn, info, debug, fail)")
+		oc.Patch(t, meshNamespace, "smcp", smcpName, "merge", loggingComponentLevelsSMCP)
+
+		t.LogStep("Wait SMCP ready")
+		oc.WaitSMCPReady(t, meshNamespace, smcpName)
+	})
+}
+
+const errorLoggingComponentLevelsSMCP = `
+spec:
+  general:
+    logging:
+      componentLevels:
+        ads: none
+        analysis: error
+        authn: warn
+        ca: info 
+        installer: trace #error
+        resource: critical #error
+`
+
+const loggingComponentLevelsSMCP = `
+spec:
+  general:
+    logging:
+      componentLevels:
+        ads: none
+        analysis: error
+        authn: warn
+        ca: info
+        installer: debug
+        resource: fatal
+`
+
+const loggingDefaut = `
+spec:
+  general:
+    logging:
+      componentLevels:
+        default: warn
+`


### PR DESCRIPTION
Close-loop

Related:
- [OSSM-7992](https://issues.redhat.com/browse/OSSM-7992)
- [OSSM-6331](https://issues.redhat.com/browse/OSSM-6331)
- [mtt-2531](https://master-jenkins-csb-servicemesh.apps.ocp-c1.prod.psi.redhat.com/job/maistra/job/maistra-test-tool/2531/console)

2.5.1 operator fail example:
```
=== RUN   TestLogging
    smcp_logging_test.go:29: This test verifies allowed logging levels for the control plane
    smcp_logging_test.go:30: See https://issues.redhat.com/browse/OSSM-6331
    smcp_logging_test.go:32:    
    smcp_logging_test.go:32: STEP 1: Deploy control plane
    smcp_logging_test.go:33:    
    smcp_logging_test.go:33: STEP 2: Apply default SMCP and SMMR manifests
    smcp_logging_test.go:33:    Wait for condition condition=Ready on smcp istio-system/basic...
    smcp_logging_test.go:33:    FAILURE: Command failed: oc wait -n istio-system smcp/basic --for condition=Ready --timeout 10s
        error: timed out waiting for the condition on servicemeshcontrolplanes/basic
        error: exit status 1
    smcp_logging_test.go:33:    Wait for condition condition=Ready on smcp istio-system/basic...
    smcp_logging_test.go:33:    FAILURE: Command failed: oc wait -n istio-system smcp/basic --for condition=Ready --timeout 10s
        error: timed out waiting for the condition on servicemeshcontrolplanes/basic
        error: exit status 1
    smcp_logging_test.go:33:    Wait for condition condition=Ready on smcp istio-system/basic...
    smcp_logging_test.go:33:    SUCCESS: Condition condition=Ready met by smcp istio-system/basic
    smcp_logging_test.go:33:    Wait for smmr/default to be ready in namespace istio-system
    smcp_logging_test.go:39:    
    smcp_logging_test.go:39: STEP 3: Try to patch SMCP with unsupported log levels (trace, critical), patch should fail
    smcp_logging_test.go:40:    FAILURE: Patch succeeded unexpectedly, unsupported log levels were not rejected; expected to find the string 'Error from server (BadRequest): admission webhook "smcp.validation.maistra.io" denied the request: [istiod doesn't support 'trace' log level, istiod doesn't support 'critical' log level]' in the output, but it wasn't found; full output:
        servicemeshcontrolplane.maistra.io/basic patched
    smcp_logging_test.go:46:    
    smcp_logging_test.go:46: STEP 4: Wait SMCP ready
    smcp_logging_test.go:47:    Wait for condition condition=Ready on smcp istio-system/basic...
    smcp_logging_test.go:47:    FAILURE: Command failed: oc wait -n istio-system smcp/basic --for condition=Ready --timeout 10s
        error: timed out waiting for the condition on servicemeshcontrolplanes/basic
```

2.6.0 operator success
```
=== RUN   TestLogging
    smcp_logging_test.go:29: This test verifies allowed logging levels for the control plane
    smcp_logging_test.go:30: See https://issues.redhat.com/browse/OSSM-6331
    smcp_logging_test.go:32:    
    smcp_logging_test.go:32: STEP 1: Deploy control plane
    smcp_logging_test.go:33:    
    smcp_logging_test.go:33: STEP 2: Apply default SMCP and SMMR manifests
    smcp_logging_test.go:33:    Wait for condition condition=Ready on smcp istio-system/basic...
    smcp_logging_test.go:33:    FAILURE: Command failed: oc wait -n istio-system smcp/basic --for condition=Ready --timeout 10s
        error: timed out waiting for the condition on servicemeshcontrolplanes/basic
        error: exit status 1
    smcp_logging_test.go:33:    Wait for condition condition=Ready on smcp istio-system/basic...
    smcp_logging_test.go:33:    FAILURE: Command failed: oc wait -n istio-system smcp/basic --for condition=Ready --timeout 10s
        error: timed out waiting for the condition on servicemeshcontrolplanes/basic
        error: exit status 1
    smcp_logging_test.go:33:    Wait for condition condition=Ready on smcp istio-system/basic...
    smcp_logging_test.go:33:    SUCCESS: Condition condition=Ready met by smcp istio-system/basic
    smcp_logging_test.go:33:    Wait for smmr/default to be ready in namespace istio-system
    smcp_logging_test.go:39:    
    smcp_logging_test.go:39: STEP 3: Try to patch SMCP with unsupported log levels (trace, critical), patch should fail
    smcp_logging_test.go:40:    SUCCESS: Patch failed as expected due to unsupported log levels
    smcp_logging_test.go:46:    
    smcp_logging_test.go:46: STEP 4: Wait SMCP ready
    smcp_logging_test.go:47:    Wait for condition condition=Ready on smcp istio-system/basic...
    smcp_logging_test.go:47:    SUCCESS: Condition condition=Ready met by smcp istio-system/basic
    smcp_logging_test.go:49:    
    smcp_logging_test.go:49: STEP 5: Try to patch SMCP with supported log levels (none, error, warn, info, debug, fail)
    smcp_logging_test.go:52:    
    smcp_logging_test.go:52: STEP 6: Wait SMCP ready
    smcp_logging_test.go:53:    Wait for condition condition=Ready on smcp istio-system/basic...
    smcp_logging_test.go:53:    SUCCESS: Condition condition=Ready met by smcp istio-system/basic
```