### PR TITLE
Fix gateway issue in ior test

### DIFF
--- a/pkg/tests/ossm/ior_test.go
+++ b/pkg/tests/ossm/ior_test.go
@@ -286,10 +286,10 @@ func TestIOR(t *testing.T) {
 			createSimpleGateway(t)
 
 			t.LogStep("Add labels argocd.argoproj.io/instance and argocd.argoproj.io/secret-type=cluster to the existing Gateway")
-			oc.Label(t, meshNamespace, "gateway", gatewayName, "argocd.argoproj.io/instance=app argocd.argoproj.io/secret-type=cluster")
+			oc.Label(t, meshNamespace, "gateway.networking.istio.io", gatewayName, "argocd.argoproj.io/instance=app argocd.argoproj.io/secret-type=cluster")
 
 			t.LogStep("Add annotations argocd.argoproj.io/instance and argocd.argoproj.io/secret-type=cluster to the existing Gateway")
-			oc.Patch(t, meshNamespace, "gateway", gatewayName, "merge", `
+			oc.Patch(t, meshNamespace, "gateway.networking.istio.io", gatewayName, "merge", `
 metadata:
   annotations:
     argocd.argoproj.io/instance: app


### PR DESCRIPTION
When Gateway API is installed in the cluster, `oc label gateway` use `gateways.gateway.networking.k8s.io` instead of `gateway.networking.istio.io` 
Due to that, you can see the following error in the `Check_argocd.argoproj.io_labels_from_Gateways_to_Routes_except_argocd.argoproj.io` test
```
    ior_test.go:288: STEP 3: Add labels argocd.argoproj.io/instance and argocd.argoproj.io/secret-type=cluster to the existing Gateway
    ior_test.go:289:    FATAL: Command failed: oc -n istio-system label gateway gw argocd.argoproj.io/instance=app argocd.argoproj.io/secret-type=cluster
        Error from server (NotFound): gateways.gateway.networking.k8s.io "gw" not found
```