### PR TITLE
Add namespace cleanup after clusterwide test

### DIFF
--- a/pkg/tests/ossm/discovery_selectors_test.go
+++ b/pkg/tests/ossm/discovery_selectors_test.go
@@ -49,6 +49,9 @@ func TestDiscoverySelectors(t *testing.T) {
 		app.InstallAndWaitReady(t, app.Sleep(ns.Foo), app.Httpbin(ns.MeshExternal))
 		t.Cleanup(func() {
 			app.Uninstall(t, app.Sleep(ns.Foo), app.Httpbin(ns.MeshExternal))
+			// since the smcp clusterwide mode was used, clean the namespace
+			t.LogStepf("Delete namespace %s", meshNamespace)
+			oc.RecreateNamespace(t, meshNamespace)
 		})
 
 		t.LogStep("Confirm that the httpbin and sleep services have been discovered")


### PR DESCRIPTION
When the SMCP with cluster-wide mode is running and the next test applies a new SMCP without any mode specified (and with smcp 2.4), there will be an error in oc apply (regression, introduced by changing oc replay to oc apply , since oc apply does a merge while oc replace does delete+create ):
```
        Error from server (BadRequest): error when applying patch:
        {"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"maistra.io/v2\",\"kind\":\"ServiceMeshControlPlane\",\"metadata\":{\"annotations\":{},\"name\":\"basic\",\"namespace\":\"istio-system\"},\"spec\":{\"addons\":{\"grafana\":{\"enabled\":true},\"kiali\":{\"enabled\":true},\"prometheus\":{\"enabled\":true}},\"policy\":{\"type\":\"Istiod\"},\"proxy\":{\"accessLogging\":{\"file\":{\"name\":\"/dev/stdout\"}}},\"runtime\":{\"components\":{\"pilot\":{\"container\":{\"env\":{\"HTTPS_PROXY\":null,\"HTTP_PROXY\":null,\"NO_PROXY\":null}}}}},\"telemetry\":{\"type\":\"Istiod\"},\"tracing\":{\"sampling\":10000},\"version\":\"v2.4\"}}\n"}},"spec":{"addons":{"grafana":{"enabled":true},"kiali":{"enabled":true},"prometheus":{"enabled":true}},"mode":null,"policy":{"type":"Istiod"},"proxy":{"accessLogging":{"file":{"name":"/dev/stdout"}}},"runtime":{"components":{"pilot":{"container":{"env":{"HTTPS_PROXY":null,"HTTP_PROXY":null,"NO_PROXY":null}}}}},"telemetry":{"type":"Istiod"},"tracing":{"sampling":10000,"type":null}}}
        to:
        Resource: "maistra.io/v2, Resource=servicemeshcontrolplanes", GroupVersionKind: "maistra.io/v2, Kind=ServiceMeshControlPlane"
        Name: "basic", Namespace: "istio-system"
        for: "STDIN": error when patching "STDIN": admission webhook "smcp.validation.maistra.io" denied the request: field spec.mode is immutable in v2.4; to change its value, upgrade the ServiceMeshControlPlane to v2.5
        error: exit status 1
```