### PR TITLE
[OSSM-8128] Use comunity prometheus operator

### DIFF
--- a/pkg/prometheusoperator/install.go
+++ b/pkg/prometheusoperator/install.go
@@ -1,0 +1,95 @@
+// Copyright 2024 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheusoperator
+
+import (
+	_ "embed"
+	"fmt"
+
+	"github.com/maistra/maistra-test-tool/pkg/util/oc"
+	"github.com/maistra/maistra-test-tool/pkg/util/operator"
+	"github.com/maistra/maistra-test-tool/pkg/util/pod"
+	"github.com/maistra/maistra-test-tool/pkg/util/retry"
+	"github.com/maistra/maistra-test-tool/pkg/util/test"
+)
+
+var (
+	//go:embed yaml/custom-prometheus-operator.yaml
+	prometheusSubscriptionYaml string
+
+	//go:embed yaml/prometheus-instance.yaml
+	prometheusInstanceYaml string
+
+	customPrometheusNamespace = "custom-prometheus-operator"
+
+	prometheusCsvName          = "prometheusoperator"
+	prometheusOperatorSelector = "app.kubernetes.io/name=prometheus-operator"
+)
+
+func Install(t test.TestHelper) {
+	oc.CreateNamespace(t, customPrometheusNamespace)
+	t.Log("Instaling custom prometheus operator...")
+	operator.CreateOperatorViaOlm(t, customPrometheusNamespace, prometheusCsvName, prometheusSubscriptionYaml, prometheusOperatorSelector, nil)
+}
+
+func Uninstall(t test.TestHelper) {
+	t.Log("Uninstalling custom prometheus")
+	oc.DeleteFromTemplate(t, customPrometheusNamespace, prometheusInstanceYaml, nil)
+	operator.DeleteOperatorViaOlm(t, customPrometheusNamespace, prometheusCsvName, prometheusSubscriptionYaml)
+	oc.DeleteNamespace(t, customPrometheusNamespace)
+}
+
+func InstalPrometheusInstance(t test.TestHelper, permittedNs ...string) {
+	oc.ApplyTemplate(t, customPrometheusNamespace, prometheusInstanceYaml, nil)
+	t.Log("Waiting for custom prometheus to be ready")
+	oc.DefaultOC.WaitFor(t, customPrometheusNamespace, "Prometheus", "prometheus", "condition=Reconciled")
+
+	for _, permitNs := range permittedNs {
+		oc.ApplyString(t, permitNs,
+			`
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: custom-prometheus-permissions
+rules:
+- apiGroups: [""]
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["get"]`,
+			fmt.Sprintf(`
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: custom-prometheus-permissions
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: custom-prometheus-permissions
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: %s`, customPrometheusNamespace))
+	}
+	retry.UntilSuccess(t, func(t test.TestHelper) {
+		prometheusPod := pod.MatchingSelector("app.kubernetes.io/name=prometheus-operator", customPrometheusNamespace)
+		oc.WaitPodRunning(t, prometheusPod)
+	})
+}

--- a/pkg/prometheusoperator/yaml/custom-prometheus-operator.yaml
+++ b/pkg/prometheusoperator/yaml/custom-prometheus-operator.yaml
@@ -1,0 +1,35 @@
+# Copyright 2024 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: custom-prometheus-operator
+  namespace: custom-prometheus-operator
+spec:
+  targetNamespaces:
+    - custom-prometheus-operator
+  upgradeStrategy: Default
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: prometheus
+  namespace: custom-prometheus-operator
+spec:
+  channel: beta
+  installPlanApproval: Automatic
+  name: prometheus
+  source: community-operators
+  sourceNamespace: openshift-marketplace

--- a/pkg/prometheusoperator/yaml/prometheus-instance.yaml
+++ b/pkg/prometheusoperator/yaml/prometheus-instance.yaml
@@ -1,0 +1,45 @@
+# Copyright 2024 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: prometheus
+spec:
+  securityContext: {}
+  serviceAccountName: prometheus-k8s
+  podMonitorSelector: {}
+  podMonitorNamespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: custom-prometheus-operator
+  serviceMonitorSelector: {}
+  serviceMonitorNamespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: custom-prometheus-operator
+  podMetadata:
+    annotations:
+      sidecar.istio.io/inject: "true"
+      traffic.sidecar.istio.io/includeInboundPorts: ""
+      traffic.sidecar.istio.io/includeOutboundIPRanges: ""
+      proxy.istio.io/config: |
+        proxyMetadata:
+          OUTPUT_CERTS: /etc/istio-output-certs
+      sidecar.istio.io/userVolumeMount: '[{"name": "istio-certs", "mountPath": "/etc/istio-output-certs"}]'
+  volumes:
+  - name: istio-certs
+    emptyDir:
+      medium: Memory
+  volumeMounts:
+  - mountPath: /etc/prom-certs/
+    name: istio-certs

--- a/pkg/util/prometheus/prometheus_struct.go
+++ b/pkg/util/prometheus/prometheus_struct.go
@@ -60,7 +60,8 @@ func (pi *prometheus_struct) Query(t test.TestHelper, ns string, query string) P
 
 	output := oc.Exec(t,
 		pod.MatchingSelectorFirst(pi.selector, ns), pi.containerName,
-		fmt.Sprintf("curl -sS -X GET '%s'", urlShellEscaped))
+		// comunity prometheus image doesn't have `curl`, use wget instead
+		fmt.Sprintf("wget -qO- '%s'", urlShellEscaped))
 
 	return parsePrometheusResponse(t, output)
 }


### PR DESCRIPTION
- Changed custom prometheus to comunity one ( since the RH one is not available anymore, see the jira ticket )
- Refactored installing of custom prometheus to use the same way as Tempo or certmanager

`TestCustomPrometheus` test passed: https://master-jenkins-csb-servicemesh.apps.ocp-c1.prod.psi.redhat.com/job/maistra/job/maistra-test-tool/2759/ 