### PR TITLE
[OSSM-8136] Add Kiali version into kiali cr + improve stability of TestOpenShiftMonitoring test

### DIFF
--- a/pkg/tests/tasks/observability/yaml/kiali-user-workload-monitoring.tmpl.yaml
+++ b/pkg/tests/tasks/observability/yaml/kiali-user-workload-monitoring.tmpl.yaml
@@ -17,6 +17,10 @@ kind: Kiali
 metadata:
   name: kiali-user-workload-monitoring
 spec:
+  version: {{ .KialiVersion }}
+  # needed for v1.65 (https://github.com/kiali/kiali-operator/blob/v1.89/roles/v1.65/kiali-deploy/tasks/main.yml#L578), it will be overridden by istio operator so it is not important
+  deployment:
+    accessible_namespaces: ["**"]
   external_services:
     prometheus:
       auth:

--- a/pkg/util/env/env.go
+++ b/pkg/util/env/env.go
@@ -114,3 +114,18 @@ func GetOutputDir() string {
 func IsMetalLBInternalIPEnabled() bool {
 	return getenv("METALLB_INTERNAL_IP_ENABLED", "false") == "true"
 }
+
+func GetKialiVersion() string {
+	switch GetSMCPVersion() {
+	case version.SMCP_2_3:
+		return "v1.57"
+	case version.SMCP_2_4:
+		return "v1.65"
+	case version.SMCP_2_5:
+		return "v1.73"
+	case version.SMCP_2_6:
+		return "v1.73"
+	default:
+		return "v1.73"
+	}
+}


### PR DESCRIPTION
* Added Kiali version to the Kiali CR to not install the same version as the operator version ( since now, it is 1.89 operator version )
* Added waiting for Prometheus target to be ready before requesting the mesh app.

Passed on all SMCP versions: https://master-jenkins-csb-servicemesh.apps.ocp-c1.prod.psi.redhat.com/job/maistra/job/maistra-test-tool/2769/
