### PR TITLE
[OSSM-8141] Fix missing Tproxy label in httpbin deployment (when TProxy=true) +  changed apps in native sidecars test from TProxy to normal variant 

### DIFF
--- a/pkg/app/httpbin.go
+++ b/pkg/app/httpbin.go
@@ -98,6 +98,7 @@ func (a *httpbin) values() map[string]interface{} {
 		"InjectSidecar": a.injectSidecar,
 		"Name":          a.deploymentName,
 		"Version":       a.versionLabel,
+		"Tproxy":        a.tproxy,
 	}
 }
 

--- a/pkg/tests/tasks/injection/native_sidecars_test.go
+++ b/pkg/tests/tasks/injection/native_sidecars_test.go
@@ -53,8 +53,8 @@ func TestNativeSidecars(t *testing.T) {
 		oc.ApplyTemplate(t, meshNamespace, meshTmpl, meshValues)
 		oc.WaitSMCPReady(t, meshNamespace, "basic")
 
-		t.LogStep("Install httpbin and sleep in mode")
-		app.InstallAndWaitReady(t, app.HttpbinTproxy(ns.Foo), app.SleepTroxy(ns.Foo))
+		t.LogStep("Install httpbin and sleep app")
+		app.InstallAndWaitReady(t, app.Httpbin(ns.Foo), app.Sleep(ns.Foo))
 
 		t.NewSubTest("HTTP request from ingress gateway to httpbin in mode").Run(func(t TestHelper) {
 			oc.ApplyFile(t, ns.Foo, "https://raw.githubusercontent.com/maistra/istio/maistra-2.6/samples/httpbin/httpbin-gateway.yaml")

--- a/pkg/tests/tasks/injection/tproxy_test.go
+++ b/pkg/tests/tasks/injection/tproxy_test.go
@@ -40,6 +40,8 @@ func TestTproxy(t *testing.T) {
 		}
 
 		t.Cleanup(func() {
+			t.LogStep("Remove privileged SCC from the app namespace")
+			shell.Executef(t, "oc adm policy remove-scc-from-group privileged system:serviceaccounts:%s", ns.Foo)
 			oc.RecreateNamespace(t, ns.Foo)
 		})
 


### PR DESCRIPTION
- The httpbin app contains `tproxy` boolean, however, the value of that boolean is not propagated into the application deployment. ( so even the `HttpbinTproxy` app is used ( which sets `tproxy:true` ) , the application deployment doesn't contain `sidecar.istio.io/interceptionMode: TPROXY` label)

-  Changed apps in native sidecars test from TProxy to normal variant 



