### PR TITLE
Add waiting for prometheus target in custom prometheus and federated openshift monitoring tests

### DIFF
--- a/pkg/tests/tasks/observability/custom_prometheus_test.go
+++ b/pkg/tests/tasks/observability/custom_prometheus_test.go
@@ -80,18 +80,28 @@ func TestCustomPrometheus(t *testing.T) {
 		enableIstioProxiesMonitoring(t, customPrometheusNs, meshNamespace, ns.Bookinfo)
 		enableAppMtlsMonitoring(t, customPrometheusNs, ns.Bookinfo)
 
+		t.LogStep("Testing if telemetry was enabled")
+		ocWaitJsonpath(t, meshNamespace, "smcp", "basic",
+			"{.status.appliedValues.istio.telemetry.enabled}", "true",
+			"Telemetry was enabled.", "Telemetry failed to enable.")
+
 		t.LogStep("Waiting for installs to complete")
 		bookinfoApp.WaitReady(t)
+
+		t.LogStep("Wait until istio targets appear in the Prometheus")
+		retry.UntilSuccess(t, func(t test.TestHelper) {
+			resp := prometheus.CustomPrometheusTargets(t, customPrometheusNs)
+			if !strings.Contains(resp, "istiod-monitor") ||
+				!strings.Contains(resp, "app-metrics-monitor-mtls") ||
+				!strings.Contains(resp, "istio-proxies-monitor") {
+				t.Error("Istio Prometheus targets istiod-monitor/app-metrics-monitor-mtls/istio-proxies-monitor are not ready")
+			}
+		})
 
 		t.LogStep("Sending request to Bookinfo app")
 		retry.UntilSuccess(t, func(t test.TestHelper) {
 			curl.Request(t, app.BookinfoProductPageURL(t, meshNamespace), nil, assert.ResponseStatus(http.StatusOK))
 		})
-
-		t.LogStep("Testing if telemetry was enabled")
-		ocWaitJsonpath(t, meshNamespace, "smcp", "basic",
-			"{.status.appliedValues.istio.telemetry.enabled}", "true",
-			"Telemetry was enabled.", "Telemetry failed to enable.")
 
 		t.LogStep("Testing if 'istio_requests_total' metric is available through Prometheus API")
 		retry.UntilSuccess(t, func(t test.TestHelper) {

--- a/pkg/util/prometheus/prometheus.go
+++ b/pkg/util/prometheus/prometheus.go
@@ -46,6 +46,7 @@ type Prometheus interface {
 	WithSelector(selector string) Prometheus
 	WithContainerName(containerName string) Prometheus
 	Query(t test.TestHelper, ns string, query string) PrometheusResponse
+	Targets(t test.TestHelper, ns string) string
 }
 
 func Query(t test.TestHelper, ns string, query string) PrometheusResponse {
@@ -56,6 +57,14 @@ func CustomPrometheusQuery(t test.TestHelper, ns string, query string) Prometheu
 	return DefaultCustomPrometheus.Query(t, ns, query)
 }
 
+func CustomPrometheusTargets(t test.TestHelper, ns string) string {
+	return DefaultCustomPrometheus.Targets(t, ns)
+}
+
 func ThanosQuery(t test.TestHelper, ns string, query string) PrometheusResponse {
 	return DefaultThanos.Query(t, ns, query)
+}
+
+func ThanosTargets(t test.TestHelper, ns string) string {
+	return DefaultThanos.Targets(t, ns)
 }


### PR DESCRIPTION
As in this PR https://github.com/maistra/maistra-test-tool/pull/740 , the waiting for the istio targets to appear in prometheus were added into custom Prometheus and federated openshift monitoring tests

Tests passed with all SMCP versions
TestFederatedOpenShiftMonitoring: https://master-jenkins-csb-servicemesh.apps.ocp-c1.prod.psi.redhat.com/job/maistra/job/maistra-test-tool/2774/ 
TestCustomPrometheus: https://master-jenkins-csb-servicemesh.apps.ocp-c1.prod.psi.redhat.com/job/maistra/job/maistra-test-tool/2775/