### PR TITLE
Fix expected output for uid/uid after base image change

### DIFF
--- a/pkg/tests/ossm/privileged_pods_test.go
+++ b/pkg/tests/ossm/privileged_pods_test.go
@@ -58,7 +58,7 @@ spec:
 		app.InstallAndWaitReady(t, app.Httpbin(ns.Foo))
 
 		t.NewSubTest("Check sleep with explicitly defined SecurityContext with same uid/gid (1001)").Run(func(t TestHelper) {
-			runSecurityContextTest(t, 1001, 1001, "uid=1002(1002) gid=1002 groups=1002")
+			runSecurityContextTest(t, 1001, 1001, "uid=1002(1002) gid=1002(1002) groups=1002(1002)")
 		})
 
 		t.NewSubTest("Check sleep with explicitly defined SecurityContext with root uid/gid").Run(func(t TestHelper) {


### PR DESCRIPTION
error from the latest builds:

```
  privileged_pods_test.go:84:    FAILURE: UID, GID and Groups were not changed; expected to find the string 'uid=1002(1002) gid=1002 groups=1002' in the output, but it wasn't found; full output:
        uid=1002(1002) gid=1002(1002) groups=1002(1002)
```

Probably the output of `id` command was changed after the proxy base image upgrade from `uid=1002(1002) gid=1002 groups=1002` to `uid=1002(1002) gid=1002(1002) groups=1002(1002)`

https://master-jenkins-csb-servicemesh.apps.ocp-c1.prod.psi.redhat.com/job/maistra/job/maistra-test-tool/2831/