### PR TITLE
OSSM-8252: Add pod locality controller fails to update pod test

### DIFF
--- a/pkg/tests/ossm/bug_istiopods_test.go
+++ b/pkg/tests/ossm/bug_istiopods_test.go
@@ -87,9 +87,7 @@ func TestControllerFailsToUpdatePod(t *testing.T) {
 
 		istioOperatorPodName := oc.GetAllResoucesNamesByLabel(t, "openshift-operators", "pod", "name=istio-operator")[0]
 
-		// Initially assumed 1 iteration, however, as issue can be flaky it could be increased up to 10 iterations
-		count := 2
-		for i := 1; i < count; i++ {
+		for i := 1; i < 11; i++ {
 			t.LogStepf("Create/Recreate 50 Namespaces, attempt #%d", i)
 			oc.RecreateNamespace(t, namespaces...)
 
@@ -115,11 +113,11 @@ func TestControllerFailsToUpdatePod(t *testing.T) {
 					t.Fatalf("Was not found success message after error for namespace %s: %s", namespaceName, successMessage)
 				}
 			} else {
-				if count < 11 {
-					count++
-					t.Logf("Was not found any 'error adding member-of label' error, repeat (max 10), attempt #%d", i)
+				if i == 10 {
+					t.Log(output)
+					t.Fatalf("Was not found any 'error adding member-of label' error, stop test, attempt #%d", i)
 				} else {
-					t.Logf("Was not found any 'error adding member-of label' error, stop test, attempt #%d", i)
+					t.Logf("Was not found any 'error adding member-of label' error, repeat (max 10), attempt #%d", i)
 				}
 			}
 		}

--- a/pkg/tests/ossm/bug_istiopods_test.go
+++ b/pkg/tests/ossm/bug_istiopods_test.go
@@ -16,16 +16,20 @@ package ossm
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/maistra/maistra-test-tool/pkg/util"
 	"github.com/maistra/maistra-test-tool/pkg/util/check/assert"
+	"github.com/maistra/maistra-test-tool/pkg/util/env"
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
 	"github.com/maistra/maistra-test-tool/pkg/util/pod"
 	"github.com/maistra/maistra-test-tool/pkg/util/retry"
+	"github.com/maistra/maistra-test-tool/pkg/util/shell"
 	"github.com/maistra/maistra-test-tool/pkg/util/template"
+
 	. "github.com/maistra/maistra-test-tool/pkg/util/test"
 )
 
@@ -52,6 +56,72 @@ func TestIstiodPodFailsAfterRestarts(t *testing.T) {
 			oc.DeletePod(t, istiodPod)
 			oc.WaitPodRunning(t, istiodPod)
 			oc.WaitPodReady(t, istiodPod)
+		}
+	})
+}
+
+func TestControllerFailsToUpdatePod(t *testing.T) {
+	NewTest(t).Groups(Full, Disconnected, ARM).Run(func(t TestHelper) {
+		t.Log("Verify that the controller does not fails to update the pod when the member controller couldn't add the member-of label")
+		t.Log("References: \n- https://issues.redhat.com/browse/OSSM-2169\n- https://issues.redhat.com/browse/OSSM-2420")
+
+		// Add timestamp to the namespaces to avoid conflicts during tests execution
+		ti := time.Now()
+		nameTemplate := fmt.Sprintf("test-smcp-%d%d-%02d%02d-",
+			env.GetSMCPVersion().Major,
+			env.GetSMCPVersion().Minor,
+			ti.Hour(), ti.Minute())
+
+		namespaces := util.GenerateStrings(nameTemplate, 100)
+		re := regexp.MustCompile(fmt.Sprintf(`error adding member-of label to namespace (%s\d+)`, nameTemplate))
+
+		t.Cleanup(func() {
+			oc.DeleteNamespace(t, namespaces...)
+			oc.ApplyString(t, meshNamespace, smmr)
+		})
+
+		DeployControlPlane(t)
+
+		t.LogStep("Add namespaces to the SMMR")
+		oc.ApplyString(t, meshNamespace, createSMMRManifest(namespaces...))
+
+		istioOperatorPodName := oc.GetResouceNameByLabel(t, "openshift-operators", "pod", "name=istio-operator")
+
+		// Initially assumed 1 iteration, however, as issue can be flaky it could be increased up to 5 iterations
+		count := 2
+		for i := 1; i < count; i++ {
+			t.LogStepf("Create/Recreate 100 Namespaces, attempt #%d", i)
+			oc.RecreateNamespace(t, namespaces...)
+
+			t.LogStepf("Check istio-operator logs for 'Error updating pod's labels', attempt #%d", i)
+			output := shell.Execute(t,
+				fmt.Sprintf("oc logs %s -n openshift-operators", istioOperatorPodName),
+				assert.OutputDoesNotContain(
+					"Error updating pod's labels",
+					"Found no updating pod's labels error",
+					"Expected to find no error updating pod's labels, but got",
+				))
+
+			t.LogStepf("Check istio-operator logs for 'error adding member-of label' errors, attempt #%d", i)
+			matches := re.FindStringSubmatch(output)
+			if len(matches) > 1 {
+				namespaceName := matches[1]
+				successMessage := fmt.Sprintf(`Added member-of label to namespace","ServiceMeshMember":"%s/default","namespace":"%s`, namespaceName, namespaceName)
+				if strings.Contains(output, successMessage) {
+					t.LogSuccessf("Found error and success message for namespace %s: %s", namespaceName, successMessage)
+					break
+				} else {
+					t.Log(output)
+					t.Fatalf("Was not found success message after error for namespace %s: %s", namespaceName, successMessage)
+				}
+			} else {
+				if count < 6 {
+					count++
+					t.Logf("Was not found any 'error adding member-of label' error, repeat (max 5), attempt #%d", i)
+				} else {
+					t.Logf("Was not found any 'error adding member-of label' error, stop test, attempt #%d", i)
+				}
+			}
 		}
 	})
 }
@@ -115,7 +185,8 @@ spec:
     - bookinfo
     - foo
     - bar
-    - legacy%s`, strings.Join(namespaces, "\n    - "))
+    - legacy
+    - %s`, strings.Join(namespaces, "\n    - "))
 }
 
 const (

--- a/pkg/tests/ossm/bug_istiopods_test.go
+++ b/pkg/tests/ossm/bug_istiopods_test.go
@@ -72,7 +72,7 @@ func TestControllerFailsToUpdatePod(t *testing.T) {
 			env.GetSMCPVersion().Minor,
 			ti.Hour(), ti.Minute())
 
-		namespaces := util.GenerateStrings(nameTemplate, 100)
+		namespaces := util.GenerateStrings(nameTemplate, 50)
 		re := regexp.MustCompile(fmt.Sprintf(`error adding member-of label to namespace (%s\d+)`, nameTemplate))
 
 		t.Cleanup(func() {
@@ -87,10 +87,10 @@ func TestControllerFailsToUpdatePod(t *testing.T) {
 
 		istioOperatorPodName := oc.GetAllResoucesNamesByLabel(t, "openshift-operators", "pod", "name=istio-operator")[0]
 
-		// Initially assumed 1 iteration, however, as issue can be flaky it could be increased up to 5 iterations
+		// Initially assumed 1 iteration, however, as issue can be flaky it could be increased up to 10 iterations
 		count := 2
 		for i := 1; i < count; i++ {
-			t.LogStepf("Create/Recreate 100 Namespaces, attempt #%d", i)
+			t.LogStepf("Create/Recreate 50 Namespaces, attempt #%d", i)
 			oc.RecreateNamespace(t, namespaces...)
 
 			t.LogStepf("Check istio-operator logs for 'Error updating pod's labels', attempt #%d", i)
@@ -115,9 +115,9 @@ func TestControllerFailsToUpdatePod(t *testing.T) {
 					t.Fatalf("Was not found success message after error for namespace %s: %s", namespaceName, successMessage)
 				}
 			} else {
-				if count < 6 {
+				if count < 11 {
 					count++
-					t.Logf("Was not found any 'error adding member-of label' error, repeat (max 5), attempt #%d", i)
+					t.Logf("Was not found any 'error adding member-of label' error, repeat (max 10), attempt #%d", i)
 				} else {
 					t.Logf("Was not found any 'error adding member-of label' error, stop test, attempt #%d", i)
 				}

--- a/pkg/tests/ossm/bug_istiopods_test.go
+++ b/pkg/tests/ossm/bug_istiopods_test.go
@@ -85,7 +85,7 @@ func TestControllerFailsToUpdatePod(t *testing.T) {
 		t.LogStep("Add namespaces to the SMMR")
 		oc.ApplyString(t, meshNamespace, createSMMRManifest(namespaces...))
 
-		istioOperatorPodName := oc.GetResouceNameByLabel(t, "openshift-operators", "pod", "name=istio-operator")
+		istioOperatorPodName := oc.GetAllResoucesNamesByLabel(t, "openshift-operators", "pod", "name=istio-operator")[0]
 
 		// Initially assumed 1 iteration, however, as issue can be flaky it could be increased up to 5 iterations
 		count := 2


### PR DESCRIPTION
Related (test covers two issues):
- [OSSM-2169](https://issues.redhat.com/browse/OSSM-2169)
- [OSSM-2420](https://issues.redhat.com/browse/OSSM-2420)
- MTT run with GA operator: [3061](https://master-jenkins-csb-servicemesh.apps.ocp-c1.prod.psi.redhat.com/job/maistra/job/maistra-test-tool/3061/)