### PR TITLE
Wait till GrpCurl job is ready

### DIFF
--- a/pkg/app/grpcurl.go
+++ b/pkg/app/grpcurl.go
@@ -52,9 +52,12 @@ func (a *grpcurl) Uninstall(t test.TestHelper) {
 
 func (a *grpcurl) WaitReady(t test.TestHelper) {
 	t.T().Helper()
-	oc.WaitDeploymentRolloutComplete(t, a.ns, "grpcurl")
+	oc.WaitCondition(t, a.ns, "Jobs", "grpcurl", "complete")
 }
 
+// TODO: if you want to use different `grpcurl` command as
+// grpcurl -insecure -authority grpc.example.com istio-ingressgateway.istio-system:443 list
+// refactor Job to Deployments and run command via `oc exec`
 const grpcCurlTemplate = `
 apiVersion: batch/v1
 kind: Job

--- a/pkg/tests/tasks/traffic/ingress/grpc_https_gateway_test.go
+++ b/pkg/tests/tasks/traffic/ingress/grpc_https_gateway_test.go
@@ -81,7 +81,7 @@ func TestExposeGrpcWithHttpsGateway(t *testing.T) {
 		oc.ApplyString(t, meshNamespace, grpcurlTLSGatewayHTTPS)
 
 		t.LogStep("Install grpcurl image")
-		app.Install(t, app.GrpCurl(ns.Default))
+		app.InstallAndWaitReady(t, app.GrpCurl(ns.Default))
 
 		retry.UntilSuccessWithOptions(t, retry.Options().MaxAttempts(20), func(t test.TestHelper) {
 			oc.LogsFromPods(t,
@@ -132,7 +132,7 @@ func TestExposeGrpcWitPassthroughGateway(t *testing.T) {
 		oc.ApplyString(t, ns.EchoGrpc, grpcurlPassthroughGatewayHTTPS)
 
 		t.LogStep("Install grpcurl image")
-		app.Install(t, app.GrpCurl(ns.Default))
+		app.InstallAndWaitReady(t, app.GrpCurl(ns.Default))
 		retry.UntilSuccessWithOptions(t, retry.Options().MaxAttempts(20), func(t test.TestHelper) {
 			oc.LogsFromPods(t,
 				ns.Default,


### PR DESCRIPTION
- removed debug resource which was added accidentally a long time ago


Test results:
- TestExposeGrpcWitPassthroughGateway https://master-jenkins-csb-servicemesh.apps.ocp-c1.prod.psi.redhat.com/job/maistra/job/maistra-test-tool/3074/
- TestExposeGrpcWithHttpsGateway https://master-jenkins-csb-servicemesh.apps.ocp-c1.prod.psi.redhat.com/job/maistra/job/maistra-test-tool/3075/ 