### PR TITLE
OSSM-1514: Expand Disconnected test cases

### DIFF
--- a/pkg/tests/non-dependant/bug_multiple_smcp_test.go
+++ b/pkg/tests/non-dependant/bug_multiple_smcp_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestSMCPMultiple(t *testing.T) {
-	NewTest(t).Id("T36").Groups(Full, ARM).Run(func(t TestHelper) {
+	NewTest(t).Id("T36").Groups(Full, ARM, Disconnected).Run(func(t TestHelper) {
 		t.Log("This test verifies whether the operator only reconciles one SMCP when two exist in a namespace")
 		t.Log("See https://issues.redhat.com/browse/OSSM-2419")
 

--- a/pkg/tests/non-dependant/olm_webhooks_test.go
+++ b/pkg/tests/non-dependant/olm_webhooks_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestOlmWebhookCreation(t *testing.T) {
-	NewTest(t).Groups(Full, ARM).Run(func(t TestHelper) {
+	NewTest(t).Groups(Full, ARM, Disconnected).Run(func(t TestHelper) {
 		t.Log("This test verifies that OLM creates all validating/mutating webhooks")
 		t.Log("See https://issues.redhat.com/browse/OSSM-6762")
 		if env.GetOperatorVersion().LessThan(version.OPERATOR_2_6_0) {

--- a/pkg/tests/ossm/bug_istiopods_test.go
+++ b/pkg/tests/ossm/bug_istiopods_test.go
@@ -61,7 +61,7 @@ func TestIstiodPodFailsAfterRestarts(t *testing.T) {
 }
 
 func TestControllerFailsToUpdatePod(t *testing.T) {
-	NewTest(t).Groups(Full, Disconnected, ARM).Run(func(t TestHelper) {
+	NewTest(t).Groups(Full, ARM).Run(func(t TestHelper) {
 		t.Log("Verify that the controller does not fails to update the pod when the member controller couldn't add the member-of label")
 		t.Log("References: \n- https://issues.redhat.com/browse/OSSM-2169\n- https://issues.redhat.com/browse/OSSM-2420")
 

--- a/pkg/tests/ossm/bug_rolebinding_test.go
+++ b/pkg/tests/ossm/bug_rolebinding_test.go
@@ -31,7 +31,7 @@ type namespaceResources struct {
 }
 
 func TestMissingRoleBinding(t *testing.T) {
-	NewTest(t).Groups(Full, ARM).Run(func(t TestHelper) {
+	NewTest(t).Groups(Full, ARM, Disconnected).Run(func(t TestHelper) {
 		t.Log("Verify that role and role binding is detected with SMMR namespace with gateway")
 		t.Log("Reference: https://issues.redhat.com/browse/OSSM-2143")
 

--- a/pkg/tests/ossm/discovery_selectors_test.go
+++ b/pkg/tests/ossm/discovery_selectors_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestDiscoverySelectors(t *testing.T) {
-	NewTest(t).Groups(Full, ARM).Run(func(t TestHelper) {
+	NewTest(t).Groups(Full, ARM, Disconnected).Run(func(t TestHelper) {
 		t.Log("This test checks if discoverySelectors are being honored")
 		t.Log("See https://issues.redhat.com/browse/OSSM-3802")
 		t.Log("Test case is based on https://istio.io/latest/blog/2021/discovery-selectors/")

--- a/pkg/tests/ossm/route_prevent_additional_ingress_test.go
+++ b/pkg/tests/ossm/route_prevent_additional_ingress_test.go
@@ -23,12 +23,13 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
 	"github.com/maistra/maistra-test-tool/pkg/util/retry"
 	"github.com/maistra/maistra-test-tool/pkg/util/shell"
-	. "github.com/maistra/maistra-test-tool/pkg/util/test"
 	"github.com/maistra/maistra-test-tool/pkg/util/version"
+
+	. "github.com/maistra/maistra-test-tool/pkg/util/test"
 )
 
 func TestRoutePreventAdditionalIngress(t *testing.T) {
-	NewTest(t).Id("T48").Groups(Full, ARM).MaxVersion(version.SMCP_2_5).Run(func(t TestHelper) {
+	NewTest(t).Id("T48").Groups(Full, ARM, Disconnected).MaxVersion(version.SMCP_2_5).Run(func(t TestHelper) {
 
 		meshValues := map[string]interface{}{
 			"Version": env.GetSMCPVersion().String(),

--- a/pkg/tests/tasks/injection/native_sidecars_test.go
+++ b/pkg/tests/tasks/injection/native_sidecars_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func TestNativeSidecars(t *testing.T) {
-	NewTest(t).Groups(Full, InterOp, ARM).Run(func(t TestHelper) {
+	NewTest(t).Groups(Full, InterOp, ARM, Disconnected).Run(func(t TestHelper) {
 		if version.ParseVersion(oc.GetOCPVersion(t)).LessThan(version.OCP_4_16) || env.GetSMCPVersion().LessThan(version.SMCP_2_6) {
 			t.Skip("Native sidecars are only supported in OpenShift 4.16+ and OSSM 2.6+")
 		}

--- a/pkg/tests/tasks/injection/tproxy_test.go
+++ b/pkg/tests/tasks/injection/tproxy_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 func TestTproxy(t *testing.T) {
-	NewTest(t).Groups(Full, InterOp, ARM).Run(func(t TestHelper) {
+	NewTest(t).Groups(Full, InterOp, ARM, Disconnected).Run(func(t TestHelper) {
 		if env.GetSMCPVersion().LessThan(version.SMCP_2_5) {
 			t.Skip("TPROXY is only supported in 2.5.3 and newer versions")
 		}

--- a/pkg/tests/tasks/security/authentication/mtls_migration_test.go
+++ b/pkg/tests/tasks/security/authentication/mtls_migration_test.go
@@ -24,11 +24,12 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/ns"
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
 	"github.com/maistra/maistra-test-tool/pkg/util/retry"
-	"github.com/maistra/maistra-test-tool/pkg/util/test"
+
+	. "github.com/maistra/maistra-test-tool/pkg/util/test"
 )
 
 func TestMTlsMigration(t *testing.T) {
-	test.NewTest(t).Id("T19").Groups(test.Full, test.InterOp, test.ARM).Run(func(t test.TestHelper) {
+	NewTest(t).Id("T19").Groups(Full, InterOp, ARM, Disconnected).Run(func(t TestHelper) {
 		meshNamespace := env.GetDefaultMeshNamespace()
 
 		t.Cleanup(func() {
@@ -49,7 +50,7 @@ func TestMTlsMigration(t *testing.T) {
 		toNamespaces := []string{ns.Foo, ns.Bar}
 
 		t.LogStep("Check connectivity from namespaces foo, bar, and legacy to namespace foo and bar")
-		retry.UntilSuccess(t, func(t test.TestHelper) {
+		retry.UntilSuccess(t, func(t TestHelper) {
 			for _, from := range fromNamespaces {
 				for _, to := range toNamespaces {
 					app.AssertSleepPodRequestSuccess(t, from, fmt.Sprintf("http://httpbin.%s:8000/ip", to))
@@ -57,12 +58,12 @@ func TestMTlsMigration(t *testing.T) {
 			}
 		})
 
-		t.NewSubTest("mTLS enabled in foo").Run(func(t test.TestHelper) {
+		t.NewSubTest("mTLS enabled in foo").Run(func(t TestHelper) {
 			t.LogStep("Apply strict mTLS in namespace foo")
 			oc.ApplyString(t, "foo", PeerAuthenticationMTLSStrict)
 
 			t.LogStep("Check connectivity from namespaces foo, bar, and legacy to namespace foo and bar (expect failure only from legacy to foo)")
-			retry.UntilSuccess(t, func(t test.TestHelper) {
+			retry.UntilSuccess(t, func(t TestHelper) {
 				for _, from := range fromNamespaces {
 					for _, to := range toNamespaces {
 						url := fmt.Sprintf("http://httpbin.%s:8000/ip", to)
@@ -76,7 +77,7 @@ func TestMTlsMigration(t *testing.T) {
 			})
 		})
 
-		t.NewSubTest("mTLS enabled globally").Run(func(t test.TestHelper) {
+		t.NewSubTest("mTLS enabled globally").Run(func(t TestHelper) {
 			t.LogStep("Apply strict mTLS for the entire mesh")
 			oc.ApplyString(t, meshNamespace, PeerAuthenticationMTLSStrict)
 			t.Cleanup(func() {
@@ -84,7 +85,7 @@ func TestMTlsMigration(t *testing.T) {
 			})
 
 			t.LogStep("Check connectivity from namespaces foo, bar, and legacy to namespace foo and bar (expect failure from legacy)")
-			retry.UntilSuccess(t, func(t test.TestHelper) {
+			retry.UntilSuccess(t, func(t TestHelper) {
 				for _, from := range fromNamespaces {
 					for _, to := range toNamespaces {
 						url := fmt.Sprintf("http://httpbin.%s:8000/ip", to)

--- a/pkg/tests/tasks/security/authorization/deny_test.go
+++ b/pkg/tests/tasks/security/authorization/deny_test.go
@@ -20,11 +20,12 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/app"
 	"github.com/maistra/maistra-test-tool/pkg/tests/ossm"
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
-	"github.com/maistra/maistra-test-tool/pkg/util/test"
+
+	. "github.com/maistra/maistra-test-tool/pkg/util/test"
 )
 
 func TestAuthorizationDenyAllow(t *testing.T) {
-	test.NewTest(t).Id("T23").Groups(test.Full, test.InterOp, test.ARM).Run(func(t test.TestHelper) {
+	NewTest(t).Id("T23").Groups(Full, InterOp, ARM, Disconnected).Run(func(t TestHelper) {
 		ns := "foo"
 		curlOptsAdmin := app.CurlOpts{Headers: []string{"x-token: admin"}}
 		curlOptsGuest := app.CurlOpts{Headers: []string{"x-token: guest"}}
@@ -42,7 +43,7 @@ func TestAuthorizationDenyAllow(t *testing.T) {
 		t.LogStep("Check if httpbin returns 200 OK when no authorization policies are in place")
 		app.AssertSleepPodRequestSuccess(t, ns, "http://httpbin:8000/ip")
 
-		t.NewSubTest("explicitly deny request").Run(func(t test.TestHelper) {
+		t.NewSubTest("explicitly deny request").Run(func(t TestHelper) {
 			t.Cleanup(func() {
 				oc.DeleteFromString(t, ns, DenyGETPolicy)
 			})
@@ -56,7 +57,7 @@ func TestAuthorizationDenyAllow(t *testing.T) {
 			app.AssertSleepPodRequestSuccess(t, ns, "http://httpbin:8000/post", app.CurlOpts{Method: "POST"})
 		})
 
-		t.NewSubTest("deny request header").Run(func(t test.TestHelper) {
+		t.NewSubTest("deny request header").Run(func(t TestHelper) {
 			t.Cleanup(func() {
 				oc.DeleteFromString(t, ns, DenyHeaderNotAdminPolicy)
 			})
@@ -70,7 +71,7 @@ func TestAuthorizationDenyAllow(t *testing.T) {
 			app.AssertSleepPodRequestForbidden(t, ns, "http://httpbin:8000/get", curlOptsGuest)
 		})
 
-		t.NewSubTest("allow request path").Run(func(t test.TestHelper) {
+		t.NewSubTest("allow request path").Run(func(t TestHelper) {
 			t.Cleanup(func() {
 				oc.DeleteFromString(t, ns, DenyHeaderNotAdminPolicy)
 				oc.DeleteFromString(t, ns, AllowPathIPPolicy)

--- a/pkg/tests/tasks/security/authorization/ext_auth_test.go
+++ b/pkg/tests/tasks/security/authorization/ext_auth_test.go
@@ -217,7 +217,7 @@ spec:
 }
 
 func TestEnvoyExtAuthzRequestPayloadTooLarge(t *testing.T) {
-	NewTest(t).Groups(Full, Disconnected, ARM).Run(func(t TestHelper) {
+	NewTest(t).Groups(Full, ARM).Run(func(t TestHelper) {
 		t.Log("Verify that Istio proxy doesn't fail with 'Request payload too large' error")
 		t.Log("Reference: https://issues.redhat.com/browse/OSSM-5850")
 

--- a/pkg/tests/tasks/security/authorization/http_test.go
+++ b/pkg/tests/tasks/security/authorization/http_test.go
@@ -23,12 +23,13 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/curl"
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
 	"github.com/maistra/maistra-test-tool/pkg/util/retry"
-	"github.com/maistra/maistra-test-tool/pkg/util/test"
+
+	. "github.com/maistra/maistra-test-tool/pkg/util/test"
 )
 
 // TestAuthorizationHTTPTraffic validates authorization policies for HTTP traffic.
 func TestAuthorizationHTTPTraffic(t *testing.T) {
-	test.NewTest(t).Id("T20").Groups(test.Full, test.ARM, test.InterOp).Run(func(t test.TestHelper) {
+	NewTest(t).Id("T20").Groups(Full, ARM, InterOp, Disconnected).Run(func(t TestHelper) {
 		ns := "bookinfo"
 		t.Cleanup(func() {
 			oc.Patch(t,
@@ -56,7 +57,7 @@ func TestAuthorizationHTTPTraffic(t *testing.T) {
 
 		productPageURL := app.BookinfoProductPageURL(t, meshNamespace)
 
-		t.NewSubTest("deny all http traffic to bookinfo").Run(func(t test.TestHelper) {
+		t.NewSubTest("deny all http traffic to bookinfo").Run(func(t TestHelper) {
 			t.Cleanup(func() {
 				oc.DeleteFromString(t, ns, DenyAllPolicy)
 			})
@@ -64,7 +65,7 @@ func TestAuthorizationHTTPTraffic(t *testing.T) {
 			oc.ApplyString(t, ns, DenyAllPolicy)
 
 			t.LogStep("Verify that GET request is denied")
-			retry.UntilSuccess(t, func(t test.TestHelper) {
+			retry.UntilSuccess(t, func(t TestHelper) {
 				curl.Request(t,
 					productPageURL,
 					nil,
@@ -73,7 +74,7 @@ func TestAuthorizationHTTPTraffic(t *testing.T) {
 			})
 		})
 
-		t.NewSubTest("only allow HTTP GET request to the productpage workload").Run(func(t test.TestHelper) {
+		t.NewSubTest("only allow HTTP GET request to the productpage workload").Run(func(t TestHelper) {
 			t.Cleanup(func() {
 				oc.DeleteFromString(t, ns, ProductpageGETPolicy)
 				oc.DeleteFromString(t, ns, DenyAllPolicy)
@@ -83,7 +84,7 @@ func TestAuthorizationHTTPTraffic(t *testing.T) {
 			oc.ApplyString(t, ns, ProductpageGETPolicy)
 
 			t.LogStep("Verify that GET request to the productpage is allowed and fetching other services is denied")
-			retry.UntilSuccess(t, func(t test.TestHelper) {
+			retry.UntilSuccess(t, func(t TestHelper) {
 				curl.Request(t,
 					productPageURL,
 					nil,
@@ -93,7 +94,7 @@ func TestAuthorizationHTTPTraffic(t *testing.T) {
 			})
 		})
 
-		t.NewSubTest("allow HTTP GET requests to all bookinfo workloads").Run(func(t test.TestHelper) {
+		t.NewSubTest("allow HTTP GET requests to all bookinfo workloads").Run(func(t TestHelper) {
 			t.Cleanup(func() {
 				oc.DeleteFromString(t, ns, RatingsGETPolicy)
 				oc.DeleteFromString(t, ns, ReviewsGETPolicy)
@@ -109,7 +110,7 @@ func TestAuthorizationHTTPTraffic(t *testing.T) {
 			oc.ApplyString(t, ns, RatingsGETPolicy)
 
 			t.LogStep("Verify that GET requests are allowed to all bookinfo workloads")
-			retry.UntilSuccess(t, func(t test.TestHelper) {
+			retry.UntilSuccess(t, func(t TestHelper) {
 				curl.Request(t,
 					productPageURL,
 					nil,

--- a/pkg/tests/tasks/security/authorization/trust_domain_test.go
+++ b/pkg/tests/tasks/security/authorization/trust_domain_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestTrustDomainMigration(t *testing.T) {
-	NewTest(t).Id("T24").Groups(Full, InterOp, ARM).Run(func(t TestHelper) {
+	NewTest(t).Id("T24").Groups(Full, InterOp, ARM, Disconnected).Run(func(t TestHelper) {
 		foo := "foo"
 		bar := "bar"
 		httpbinUrl := "http://httpbin.foo:8000/ip"

--- a/pkg/tests/tasks/security/certificate/external_ca_test.go
+++ b/pkg/tests/tasks/security/certificate/external_ca_test.go
@@ -27,11 +27,12 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
 	"github.com/maistra/maistra-test-tool/pkg/util/pod"
 	"github.com/maistra/maistra-test-tool/pkg/util/retry"
-	"github.com/maistra/maistra-test-tool/pkg/util/test"
+
+	. "github.com/maistra/maistra-test-tool/pkg/util/test"
 )
 
 func TestExternalCertificate(t *testing.T) {
-	test.NewTest(t).Id("T17").Groups(test.Full, test.ARM, test.InterOp).Run(func(t test.TestHelper) {
+	NewTest(t).Id("T17").Groups(Full, ARM, InterOp, Disconnected).Run(func(t TestHelper) {
 		const ns = "bookinfo"
 
 		t.Cleanup(func() {
@@ -65,7 +66,7 @@ func TestExternalCertificate(t *testing.T) {
 		app.InstallAndWaitReady(t, app.BookinfoWithMTLS(ns))
 
 		t.LogStep("Wait for response from productpage app")
-		retry.UntilSuccess(t, func(t test.TestHelper) {
+		retry.UntilSuccess(t, func(t TestHelper) {
 			curl.Request(t,
 				app.BookinfoProductPageURL(t, meshNamespace), nil,
 				assert.ResponseStatus(200))
@@ -74,7 +75,7 @@ func TestExternalCertificate(t *testing.T) {
 		t.LogStep("Retrieve certificates from bookinfo details service")
 
 		var returnedCerts []*x509.Certificate
-		retry.UntilSuccess(t, func(t test.TestHelper) {
+		retry.UntilSuccess(t, func(t TestHelper) {
 			opensslOutput := oc.Exec(t,
 				pod.MatchingSelector("app=productpage", ns), "istio-proxy",
 				`openssl s_client -showcerts -connect details:9080 || true`) // the "|| true" is needed until oc.Exec can ignore return codes
@@ -93,7 +94,7 @@ func TestExternalCertificate(t *testing.T) {
 	})
 }
 
-func verifyContainsCerts(t test.TestHelper, actualCerts, expectedCerts []*x509.Certificate, successMsg, failureMsg string) {
+func verifyContainsCerts(t TestHelper, actualCerts, expectedCerts []*x509.Certificate, successMsg, failureMsg string) {
 	t.T().Helper()
 
 	// Make a copy of expectedCerts because we will clobber it
@@ -118,7 +119,7 @@ func verifyContainsCerts(t test.TestHelper, actualCerts, expectedCerts []*x509.C
 	t.Error(failureMsg)
 }
 
-func verifyCertificate(t test.TestHelper, cert *x509.Certificate, rootCerts, intermediateCerts []*x509.Certificate, successMsg, failureMsg string) {
+func verifyCertificate(t TestHelper, cert *x509.Certificate, rootCerts, intermediateCerts []*x509.Certificate, successMsg, failureMsg string) {
 	t.T().Helper()
 	rootCertPool := x509.NewCertPool()
 	for _, c := range rootCerts {
@@ -149,7 +150,7 @@ func verifyCertificate(t test.TestHelper, cert *x509.Certificate, rootCerts, int
 	}
 }
 
-func readPemCertificatesFromFile(t test.TestHelper, path string) []*x509.Certificate {
+func readPemCertificatesFromFile(t TestHelper, path string) []*x509.Certificate {
 	t.T().Helper()
 	bytes, err := os.ReadFile(path)
 	if err != nil {
@@ -158,13 +159,13 @@ func readPemCertificatesFromFile(t test.TestHelper, path string) []*x509.Certifi
 	return readPemCertificates(t, bytes)
 }
 
-func readPemCertificatesFromText(t test.TestHelper, text string) []*x509.Certificate {
+func readPemCertificatesFromText(t TestHelper, text string) []*x509.Certificate {
 	t.T().Helper()
 
 	return readPemCertificates(t, []byte(text))
 }
 
-func readPemCertificates(t test.TestHelper, pemData []byte) []*x509.Certificate {
+func readPemCertificates(t TestHelper, pemData []byte) []*x509.Certificate {
 	t.T().Helper()
 	var certificates []*x509.Certificate
 	for {

--- a/pkg/tests/tasks/traffic/egress/access_external_services_test.go
+++ b/pkg/tests/tasks/traffic/egress/access_external_services_test.go
@@ -26,11 +26,12 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/ns"
 	"github.com/maistra/maistra-test-tool/pkg/util/oc"
 	"github.com/maistra/maistra-test-tool/pkg/util/pod"
-	"github.com/maistra/maistra-test-tool/pkg/util/test"
+
+	. "github.com/maistra/maistra-test-tool/pkg/util/test"
 )
 
 func TestAccessExternalServices(t *testing.T) {
-	test.NewTest(t).Id("T11").Groups(test.Full, test.InterOp, test.ARM).Run(func(t test.TestHelper) {
+	NewTest(t).Id("T11").Groups(Full, InterOp, ARM, Disconnected).Run(func(t TestHelper) {
 		smcpName := env.GetDefaultSMCPName()
 		t.Cleanup(func() {
 			app.Uninstall(t, app.Sleep(ns.Bookinfo))
@@ -80,7 +81,7 @@ func TestAccessExternalServices(t *testing.T) {
 		t.LogStep("Make request to external httpbin from sleep again, and expect it denied")
 		app.AssertSleepPodRequestFailure(t, ns.Bookinfo, httpbinHeadersUrl)
 
-		t.NewSubTest("allow request to external httpbin after applying ServiceEntry").Run(func(t test.TestHelper) {
+		t.NewSubTest("allow request to external httpbin after applying ServiceEntry").Run(func(t TestHelper) {
 			t.Cleanup(func() {
 				oc.DeleteFromString(t, ns.Bookinfo, httpbinServiceEntry)
 			})

--- a/pkg/tests/tasks/traffic/fault_injection_test.go
+++ b/pkg/tests/tasks/traffic/fault_injection_test.go
@@ -40,7 +40,7 @@ var (
 )
 
 func TestFaultInjection(t *testing.T) {
-	NewTest(t).Id("T2").Groups(Full, InterOp, ARM).Run(func(t TestHelper) {
+	NewTest(t).Id("T2").Groups(Full, InterOp, ARM, Disconnected).Run(func(t TestHelper) {
 
 		t.Cleanup(func() {
 			oc.RecreateNamespace(t, ns.Bookinfo)

--- a/pkg/tests/tasks/traffic/ingress/gatewayapi_test.go
+++ b/pkg/tests/tasks/traffic/ingress/gatewayapi_test.go
@@ -39,7 +39,7 @@ type EnvVar struct {
 }
 
 func TestGatewayApi(t *testing.T) {
-	NewTest(t).Id("T41").Groups(Full, InterOp, ARM).Run(func(t TestHelper) {
+	NewTest(t).Id("T41").Groups(Full, InterOp, ARM, Disconnected).Run(func(t TestHelper) {
 		if env.GetSMCPVersion().LessThan(version.SMCP_2_3) {
 			t.Skip("TestGatewayApi was added in v2.3")
 		}

--- a/pkg/tests/tasks/traffic/ingress/ingress_gateways_test.go
+++ b/pkg/tests/tasks/traffic/ingress/ingress_gateways_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 func TestIngressGateways(t *testing.T) {
-	NewTest(t).Id("T8").Groups(Full, InterOp, ARM).Run(func(t TestHelper) {
+	NewTest(t).Id("T8").Groups(Full, InterOp, ARM, Disconnected).Run(func(t TestHelper) {
 
 		t.Cleanup(func() {
 			oc.RecreateNamespace(t, ns.Bookinfo)

--- a/pkg/tests/tasks/traffic/request_routing_test.go
+++ b/pkg/tests/tasks/traffic/request_routing_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestRequestRouting(t *testing.T) {
-	NewTest(t).Id("T1").Groups(Smoke, Full, InterOp, ARM).Run(func(t TestHelper) {
+	NewTest(t).Id("T1").Groups(Smoke, Full, InterOp, ARM, Disconnected).Run(func(t TestHelper) {
 
 		t.Cleanup(func() {
 			oc.RecreateNamespace(t, ns.Bookinfo)

--- a/pkg/tests/tasks/traffic/request_timeouts_test.go
+++ b/pkg/tests/tasks/traffic/request_timeouts_test.go
@@ -35,7 +35,7 @@ import (
 var reviewTimeout string
 
 func TestRequestTimeouts(t *testing.T) {
-	NewTest(t).Id("T5").Groups(Full, InterOp, ARM).Run(func(t TestHelper) {
+	NewTest(t).Id("T5").Groups(Full, InterOp, ARM, Disconnected).Run(func(t TestHelper) {
 
 		t.Cleanup(func() {
 			oc.RecreateNamespace(t, ns.Bookinfo)

--- a/pkg/tests/tasks/traffic/traffic_mirroring_test.go
+++ b/pkg/tests/tasks/traffic/traffic_mirroring_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestMirroring(t *testing.T) {
-	NewTest(t).Id("T7").Groups(Full, InterOp, ARM).Run(func(t TestHelper) {
+	NewTest(t).Id("T7").Groups(Full, InterOp, ARM, Disconnected).Run(func(t TestHelper) {
 
 		t.Cleanup(func() {
 			oc.RecreateNamespace(t, ns.Bookinfo)

--- a/pkg/tests/tasks/traffic/traffic_shifting_test.go
+++ b/pkg/tests/tasks/traffic/traffic_shifting_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 func TestTrafficShifting(t *testing.T) {
-	NewTest(t).Id("T3").Groups(Full, InterOp, ARM).Run(func(t TestHelper) {
+	NewTest(t).Id("T3").Groups(Full, InterOp, ARM, Disconnected).Run(func(t TestHelper) {
 
 		t.Cleanup(func() {
 			oc.RecreateNamespace(t, ns.Bookinfo)


### PR DESCRIPTION
- Add Disconnected label on passed tests
- Clean-up
- stabilize flaky tests
- investigate failed tests and the possibility of the next expansion (need to expand mirroring)

Related:

- MTT - [3120](https://master-jenkins-csb-servicemesh.apps.ocp-c1.prod.psi.redhat.com/job/maistra/job/maistra-test-tool/3120/console)
- [OSSM-1514](https://issues.redhat.com/browse/OSSM-1514)