### PR TITLE
Add a test for 2.6 --> 3.0 migration

### DIFF
--- a/pkg/tests/ossm/setup.go
+++ b/pkg/tests/ossm/setup.go
@@ -27,6 +27,12 @@ import (
 	"github.com/maistra/maistra-test-tool/pkg/util/version"
 )
 
+type Istio struct {
+	Name      string
+	Namespace string
+	Version   string
+}
+
 type SMCP struct {
 	Name          string
 	Namespace     string
@@ -90,6 +96,14 @@ func DefaultClusterWideSMCP() SMCP {
 		Version:       env.GetSMCPVersion(),
 		Rosa:          env.IsRosa(),
 		ClusterWideCp: true,
+	}
+}
+
+func DefaultIstio() Istio {
+	return Istio{
+		Name:      env.GetIstioName(),
+		Namespace: env.GetIstioNamespace(),
+		Version:   env.GetIstioVersion(),
 	}
 }
 

--- a/pkg/tests/tasks/migration/bookinfo-gateway.yaml
+++ b/pkg/tests/tasks/migration/bookinfo-gateway.yaml
@@ -145,3 +145,15 @@ spec:
             host: productpage
             port:
               number: 9080
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: bookinfo-gateway
+spec:
+  to:
+    name: bookinfo-gateway
+    weight: 100
+    kind: Service
+  port:
+    targetPort: http2

--- a/pkg/tests/tasks/migration/bookinfo-gateway.yaml
+++ b/pkg/tests/tasks/migration/bookinfo-gateway.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: secret-reader
+  name: bookinfo-gateway
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -29,14 +29,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: secret-reader
+  name: bookinfo-gateway-secret-reader
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: secret-reader
 subjects:
   - kind: ServiceAccount
-    name: secret-reader
+    name: bookinfo-gateway
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -57,30 +57,7 @@ spec:
       containers:
         - name: istio-proxy
           image: auto
-          securityContext:
-            capabilities:
-              drop:
-                - ALL
-            allowPrivilegeEscalation: false
-            privileged: false
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-          ports:
-            - containerPort: 15090
-              protocol: TCP
-              name: http-envoy-prom
-          resources:
-            limits:
-              cpu: 2000m
-              memory: 1024Mi
-            requests:
-              cpu: 100m
-              memory: 128Mi
-      securityContext:
-        sysctls:
-          - name: net.ipv4.ip_unprivileged_port_start
-            value: "0"
-      serviceAccountName: secret-reader
+      serviceAccountName: bookinfo-gateway
 ---
 apiVersion: v1
 kind: Service

--- a/pkg/tests/tasks/migration/bookinfo-gateway.yaml
+++ b/pkg/tests/tasks/migration/bookinfo-gateway.yaml
@@ -1,0 +1,147 @@
+# Copyright 2024 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: secret-reader
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: secret-reader
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: secret-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: secret-reader
+subjects:
+  - kind: ServiceAccount
+    name: secret-reader
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bookinfo-gateway
+spec:
+  selector:
+    matchLabels:
+      istio: bookinfo-gateway
+  template:
+    metadata:
+      annotations:
+        inject.istio.io/templates: gateway
+      labels:
+        istio: bookinfo-gateway
+        sidecar.istio.io/inject: "true"
+    spec:
+      containers:
+        - name: istio-proxy
+          image: auto
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          ports:
+            - containerPort: 15090
+              protocol: TCP
+              name: http-envoy-prom
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 1024Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+      securityContext:
+        sysctls:
+          - name: net.ipv4.ip_unprivileged_port_start
+            value: "0"
+      serviceAccountName: secret-reader
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bookinfo-gateway
+spec:
+  type: LoadBalancer
+  selector:
+    istio: bookinfo-gateway
+  ports:
+    - name: status-port
+      port: 15021
+      protocol: TCP
+      targetPort: 15021
+    - name: http2
+      port: 80
+      protocol: TCP
+      targetPort: 80
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: 443
+---
+apiVersion: networking.istio.io/v1
+kind: Gateway
+metadata:
+  name: bookinfo-gateway
+spec:
+  selector:
+    istio: bookinfo-gateway
+  servers:
+    - port:
+        number: 80
+        name: http2
+        protocol: HTTP
+      hosts:
+        - "*"
+---
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: bookinfo
+spec:
+  hosts:
+    - "*"
+  gateways:
+    - bookinfo-gateway
+  http:
+    - match:
+        - uri:
+            exact: /productpage
+        - uri:
+            prefix: /static
+        - uri:
+            exact: /login
+        - uri:
+            exact: /logout
+        - uri:
+            prefix: /api/v1/products
+      route:
+        - destination:
+            host: productpage
+            port:
+              number: 9080

--- a/pkg/tests/tasks/migration/main_test.go
+++ b/pkg/tests/tasks/migration/main_test.go
@@ -1,0 +1,35 @@
+// Copyright 2024 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	_ "embed"
+	"testing"
+
+	"github.com/maistra/maistra-test-tool/pkg/tests/ossm"
+	"github.com/maistra/maistra-test-tool/pkg/util/env"
+	"github.com/maistra/maistra-test-tool/pkg/util/test"
+)
+
+var (
+	meshNamespace               = env.GetDefaultMeshNamespace()
+	migrationGateway            = "bookinfo-gateway.yaml"
+)
+
+func TestMain(m *testing.M) {
+	test.NewSuite(m).
+		Setup(ossm.BasicSetup).
+		Run()
+}

--- a/pkg/tests/tasks/migration/main_test.go
+++ b/pkg/tests/tasks/migration/main_test.go
@@ -24,8 +24,8 @@ import (
 )
 
 var (
-	meshNamespace               = env.GetDefaultMeshNamespace()
-	migrationGateway            = "bookinfo-gateway.yaml"
+	meshNamespace    = env.GetDefaultMeshNamespace()
+	migrationGateway = "bookinfo-gateway.yaml"
 )
 
 func TestMain(m *testing.M) {

--- a/pkg/tests/tasks/migration/migration_test.go
+++ b/pkg/tests/tasks/migration/migration_test.go
@@ -1,0 +1,149 @@
+// Copyright 2024 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/maistra/maistra-test-tool/pkg/app"
+	"github.com/maistra/maistra-test-tool/pkg/tests/ossm"
+	"github.com/maistra/maistra-test-tool/pkg/util/check/assert"
+	"github.com/maistra/maistra-test-tool/pkg/util/curl"
+	"github.com/maistra/maistra-test-tool/pkg/util/ns"
+	"github.com/maistra/maistra-test-tool/pkg/util/oc"
+	"github.com/maistra/maistra-test-tool/pkg/util/pod"
+	"github.com/maistra/maistra-test-tool/pkg/util/retry"
+	"github.com/maistra/maistra-test-tool/pkg/util/test"
+	"github.com/maistra/maistra-test-tool/pkg/util/version"
+)
+
+func TestMigrationSimpleClusterWide(t *testing.T) {
+	test.NewTest(t).MinVersion(version.SMCP_2_6).Groups(test.Full).Run(func(t test.TestHelper) {
+		t.Cleanup(func() {
+			oc.DeleteResource(t, "", "Istio", "example")
+			oc.DeleteResource(t, "", "IstioCNI", "default")
+		})
+		defaults := ossm.DefaultClusterWideSMCP()
+		ossm.BasicSetup(t)
+		templ := `apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+metadata:
+  name: {{ .Name }}
+spec:
+  version: {{ .Version }}
+  tracing:
+    type: None
+  security:
+    manageNetworkPolicy: false
+  gateways:
+    enabled: false
+  policy:
+    type: Istiod
+  addons:
+    grafana:
+      enabled: false
+    kiali:
+      enabled: false
+    prometheus:
+      enabled: false
+  mode: ClusterWide`
+		oc.ApplyTemplate(t, defaults.Namespace, templ, defaults)
+
+		oc.WaitSMCPReady(t, defaults.Namespace, defaults.Name)
+		oc.WaitSMMRReady(t, defaults.Namespace)
+		oc.Label(t, "", "Namespace", ns.Bookinfo, "istio-injection=enabled")
+		t.LogStep("Update SMMR to include bookinfo namespace")
+		// Wait for SMMR to include bookinfo
+		oc.DefaultOC.WaitFor(t, defaults.Namespace, "ServiceMeshMemberRoll", "default", `jsonpath='{.status.configuredMembers[?(@=="bookinfo")]}'`)
+
+		t.LogStep("Create 3.0 controlplane and IstioCNI")
+		istio := `apiVersion: sailoperator.io/v1alpha1
+kind: Istio
+metadata:
+  name: example
+spec:
+  namespace: istio-system
+  version: v1.24.1`
+		oc.ApplyString(t, "", istio)
+		oc.DefaultOC.WaitFor(t, "", "Istio", "example", "condition=Ready")
+		oc.CreateNamespace(t, "istio-cni")
+		istioCNI := `apiVersion: sailoperator.io/v1alpha1
+kind: IstioCNI
+metadata:
+  name: default
+spec:
+  namespace: istio-cni
+  version: v1.24.1`
+		oc.ApplyString(t, "", istioCNI)
+
+		t.LogStep("Install bookinfo and bookinfo gateway")
+		app.InstallAndWaitReady(t, app.Bookinfo(ns.Bookinfo))
+
+		oc.ApplyFile(t, ns.Bookinfo, "bookinfo-gateway.yaml")
+		oc.DefaultOC.WaitDeploymentRolloutComplete(t, "bookinfo", "bookinfo-gateway")
+		ip := oc.DefaultOC.Invokef(t, "kubectl get service -n %s %s -o jsonpath='{.status.loadBalancer.ingress[0].ip}'", ns.Bookinfo, "bookinfo-gateway")
+		bookinfoGatewayURL := fmt.Sprintf("http://%s/productpage", ip)
+		curl.Request(t, bookinfoGatewayURL, nil, assert.RequestSucceeds("productpage request succeeded", "productpage request failed"))
+
+		t.LogStep("Migrate bookinfo to 3.0 controlplane")
+		oc.Label(t, "", "Namespace", ns.Bookinfo, "istio-injection- istio.io/rev=example")
+		// Wait for book info to be removed.
+		retry.UntilSuccess(t, func(t test.TestHelper) {
+			var members []string
+			output := oc.GetJson(t, defaults.Namespace, "ServiceMeshMemberRoll", "default", "{.status.configuredMembers}")
+			if err := json.Unmarshal([]byte(output), &members); err != nil {
+				t.Error(err)
+			}
+			contains := false
+			for _, member := range members {
+				if member == "bookinfo" {
+					contains = true
+					break
+				}
+			}
+			if contains {
+				t.Error("bookinfo found in SMMR. Expected it to be removed.")
+			}
+		})
+		oc.RestartAllPodsAndWaitReady(t, ns.Bookinfo)
+		workloads := []string{
+			"productpage-v1",
+			"reviews-v1",
+			"reviews-v2",
+			"reviews-v3",
+			"ratings-v1",
+			"details-v1",
+		}
+		// Waiting for the rollouts to complete ensures that old pods have been deleted.
+		// If there are old pods lying around then the assertion below to get the pod annotations
+		// will fail.
+		oc.WaitDeploymentRolloutComplete(t, ns.Bookinfo, workloads...)
+
+		t.LogStep("Ensure all pods have migrated to 3.0 controlplane and curl requests succeed")
+		for _, workload := range workloads {
+			arr := strings.Split(workload, "-")
+			app, version := arr[0], arr[1]
+			annotations := oc.GetPodAnnotations(t, pod.MatchingSelector(fmt.Sprintf("app=%s,version=%s", app, version), ns.Bookinfo))
+			if actual := annotations["istio.io/rev"]; actual != "example" {
+				t.Fatalf("Expected example. Got: %s", actual)
+			}
+		}
+
+		curl.Request(t, bookinfoGatewayURL, nil, assert.RequestSucceeds("productpage request succeeded", "productpage request failed"))
+	})
+}

--- a/pkg/tests/tasks/migration/migration_test.go
+++ b/pkg/tests/tasks/migration/migration_test.go
@@ -35,8 +35,7 @@ import (
 )
 
 func TestMigrationSimpleClusterWide(t *testing.T) {
-	test.NewTest(t).MinVersion(version.SMCP_2_6).Groups(test.Full, test.Migration).Run(func(t test.TestHelper) {
-		
+	test.NewTest(t).MinVersion(version.SMCP_2_6).Groups(test.Migration).Run(func(t test.TestHelper) {
 		// delete mesh namespace from previous tests
 		t.LogStepf("Delete namespace %s", meshNamespace)
 		oc.RecreateNamespace(t, meshNamespace)

--- a/pkg/util/curl/curl.go
+++ b/pkg/util/curl/curl.go
@@ -15,6 +15,7 @@
 package curl
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/cookiejar"
@@ -107,4 +108,19 @@ func (n NilRequestOption) ApplyToClient(client *http.Client) error {
 
 func (n NilRequestOption) ApplyToRequest(req *http.Request) error {
 	return nil
+}
+
+type contextModifier struct {
+	Context context.Context
+	NilRequestOption
+}
+
+func (c contextModifier) ApplyToRequest(req *http.Request) error {
+	newReq := req.Clone(c.Context)
+	*req = *newReq
+	return nil
+}
+
+func WithContext(ctx context.Context) RequestOption {
+	return contextModifier{Context: ctx}
 }

--- a/pkg/util/env/env.go
+++ b/pkg/util/env/env.go
@@ -55,6 +55,18 @@ func IsNightly() bool {
 	return getenv("NIGHTLY", "false") == "true"
 }
 
+func GetIstioName() string {
+	return getenv("ISTIO_NAME", "ossm3")
+}
+
+func GetIstioNamespace() string {
+	return getenv("ISTIO_NAMESPACE", "istio-system")
+}
+
+func GetIstioVersion() string {
+	return getenv("ISTIO_VERSION", "v1.24.1")
+}
+
 func GetDefaultSMCPName() string {
 	return getenv("SMCP_NAME", "basic")
 }

--- a/pkg/util/oc/pod_commands.go
+++ b/pkg/util/oc/pod_commands.go
@@ -183,7 +183,7 @@ func (o OC) WaitFor(t test.TestHelper, ns string, kind string, name string, forC
 		attemptT = retry.Attempt(t, func(t test.TestHelper) {
 			t.T().Helper()
 			shell.Execute(t,
-				fmt.Sprintf(`oc wait -n %s %s/%s --for %s --timeout %s`, ns, kind, name, forCondition, "10s"),
+				fmt.Sprintf(`oc wait %s %s/%s --for %s --timeout %s`, nsFlag(ns), kind, name, forCondition, "10s"),
 				require.OutputContains("condition met",
 					fmt.Sprintf("Condition %s met by %s %s/%s", forCondition, kind, ns, name),
 					fmt.Sprintf("Condition %s not met by %s %s/%s", forCondition, kind, ns, name)))

--- a/pkg/util/test/test.go
+++ b/pkg/util/test/test.go
@@ -30,6 +30,7 @@ type TestGroup string
 const (
 	ARM          TestGroup = "arm64"
 	Full         TestGroup = "full"
+	Migration    TestGroup = "migration"
 	Smoke        TestGroup = "smoke"
 	InterOp      TestGroup = "interop"
 	Disconnected TestGroup = "disconnected"


### PR DESCRIPTION
Adds a test that:
1. Creates a 2.6 and 3.0 controlplane.
2. Deploys bookinfo + bookinfo gateway.
3. Migrates bookinfo from 2.6 --> 3.0 controlplane.
4. Ensures that requests to bookinfo through the gateway succeed before and after migration.

Subsequent tests should make common methods for things like creating and cleaning up `Istio` and `IstioCNI` resource.

This test also requires that your cluster can provision `LoadBalancer` services. 