### PR TITLE
[OSSM-9386] Do not select Jaeger tracing on OCP 4.19+

### DIFF
--- a/pkg/tests/non-dependant/bug_multiple_smcp_test.go
+++ b/pkg/tests/non-dependant/bug_multiple_smcp_test.go
@@ -56,7 +56,7 @@ func TestSMCPMultiple(t *testing.T) {
 		oc.RecreateNamespace(t, meshNamespace)
 
 		t.LogStep("Create the first SMCP")
-		smcp1 := ossm.DefaultSMCP().WithName("smcp1")
+		smcp1 := ossm.DefaultSMCP(t).WithName("smcp1")
 		ossm.InstallSMCPCustom(t, meshNamespace, smcp1)
 
 		t.LogStep("Check whether the first SMCP gets reconciled and becomes ready")
@@ -74,7 +74,7 @@ func TestSMCPMultiple(t *testing.T) {
 			t.LogStep("Delete the operator's ValidationWebhookConfiguration to be able to install the second SMCP")
 			oc.DeleteResource(t, "", "validatingwebhookconfiguration", "openshift-operators.servicemesh-resources.maistra.io")
 			t.LogStep("Create the second SMCP")
-			smcp2 := ossm.DefaultSMCP().WithName("smcp2")
+			smcp2 := ossm.DefaultSMCP(t).WithName("smcp2")
 			ossm.InstallSMCPCustom(t, meshNamespace, smcp2)
 			ossm.InstallSMCPCustom(t, meshNamespace, smcp2)
 

--- a/pkg/tests/ossm/bug_istiopods_test.go
+++ b/pkg/tests/ossm/bug_istiopods_test.go
@@ -129,7 +129,7 @@ func TestIstiodPodFailsWithValidationMessages(t *testing.T) {
 		t.Log("Verify that Istio pod is not failing when validationMessages was enabled")
 
 		oc.RecreateNamespace(t, meshNamespace)
-		oc.ApplyString(t, meshNamespace, template.Run(t, validationMessagesSMCP, DefaultSMCP()))
+		oc.ApplyString(t, meshNamespace, template.Run(t, validationMessagesSMCP, DefaultSMCP(t)))
 		t.Cleanup(func() {
 			oc.RecreateNamespace(t, meshNamespace)
 		})

--- a/pkg/tests/ossm/deploy_on_infra_test.go
+++ b/pkg/tests/ossm/deploy_on_infra_test.go
@@ -131,7 +131,8 @@ spec:
 
 			t.LogStep("Verify that the following control plane pods are running on the infra node: istiod, istio-ingressgateway, istio-egressgateway, jaeger, grafana, prometheus")
 			istioPodLabelSelectors := []string{"app=istiod", "app=istio-ingressgateway", "app=istio-egressgateway", "app=grafana", "app=prometheus"}
-			if env.GetSMCPVersion().LessThanOrEqual(version.SMCP_2_5) {
+			// jaeger is not available on SMCP 2.6 or OCP 4.19+, so use Jaeger tracing only for SMCP 2.5 and lower and OCP 4.18 and lower
+			if env.GetSMCPVersion().LessThanOrEqual(version.SMCP_2_5) && version.ParseVersion(oc.GetOCPVersion(t)).LessThanOrEqual(version.OCP_4_18) {
 				istioPodLabelSelectors = append(istioPodLabelSelectors, "app=jaeger")
 			}
 			for _, pLabel := range istioPodLabelSelectors {

--- a/pkg/tests/ossm/ior_test.go
+++ b/pkg/tests/ossm/ior_test.go
@@ -472,7 +472,7 @@ func enableIOR(t TestHelper, ns, name string) {
 		ns, "smcp", name, "json",
 		`[{"op": "add", "path": "/spec/gateways", "value": {"openshiftRoute": {"enabled": true}}}]`,
 	)
-	oc.WaitSMCPReady(t, meshNamespace, DefaultSMCP().Name)
+	oc.WaitSMCPReady(t, meshNamespace, name)
 }
 
 func removeIORCustomSetting(t TestHelper, ns, name string) {
@@ -481,7 +481,7 @@ func removeIORCustomSetting(t TestHelper, ns, name string) {
 		ns, "smcp", name, "json",
 		`[{"op": "remove", "path": "/spec/gateways"}]`,
 	)
-	oc.WaitSMCPReady(t, meshNamespace, DefaultSMCP().Name)
+	oc.WaitSMCPReady(t, meshNamespace, name)
 }
 
 func generateGateway(name, ns, host string) string {

--- a/pkg/tests/ossm/ratelimit_test.go
+++ b/pkg/tests/ossm/ratelimit_test.go
@@ -69,9 +69,10 @@ func TestRateLimiting(t *testing.T) {
 				"ERROR: rls pod expected to be running, but it is not"))
 
 		t.LogStep("Create EnvoyFilter for rate limiting")
-		oc.ApplyTemplate(t, meshNamespace, rateLimitFilterTemplate, DefaultSMCP())
+		smcp := DefaultSMCP(t)
+		oc.ApplyTemplate(t, meshNamespace, rateLimitFilterTemplate, smcp)
 		t.Cleanup(func() {
-			oc.DeleteFromTemplate(t, meshNamespace, rateLimitFilterTemplate, DefaultSMCP())
+			oc.DeleteFromTemplate(t, meshNamespace, rateLimitFilterTemplate, smcp)
 		})
 
 		productPageURL := app.BookinfoProductPageURL(t, meshNamespace)

--- a/pkg/tests/ossm/route_prevent_additional_ingress_test.go
+++ b/pkg/tests/ossm/route_prevent_additional_ingress_test.go
@@ -31,9 +31,14 @@ import (
 func TestRoutePreventAdditionalIngress(t *testing.T) {
 	NewTest(t).Id("T48").Groups(Full, ARM, Disconnected, Persistent).MaxVersion(version.SMCP_2_5).Run(func(t TestHelper) {
 
+		tracingType := "None"
+		if env.GetSMCPVersion().LessThanOrEqual(version.SMCP_2_5) && version.ParseVersion(oc.GetOCPVersion(t)).LessThanOrEqual(version.OCP_4_18) {
+			tracingType = "Jaeger"
+		}
 		meshValues := map[string]interface{}{
-			"Version": env.GetSMCPVersion().String(),
-			"Rosa":    env.IsRosa(),
+			"Version":     env.GetSMCPVersion().String(),
+			"Rosa":        env.IsRosa(),
+			"TracingType": tracingType,
 		}
 
 		ER := "extra-routes"
@@ -97,6 +102,7 @@ spec:
   version: {{ .Version }}
   tracing:
     sampling: 10000
+    type: {{ .TracingType }}
   policy:
     type: Istiod
   telemetry:
@@ -121,6 +127,9 @@ metadata:
   name: basic
 spec:
   version: {{ .Version }}
+  tracing:
+    sampling: 10000
+    type: {{ .TracingType }}
   gateways: 
     additionalIngress: 
       test-ingress: 

--- a/pkg/tests/ossm/smoke_test.go
+++ b/pkg/tests/ossm/smoke_test.go
@@ -283,7 +283,8 @@ func assertRoutesExist(t TestHelper) {
 				"Still waiting for route prometheus to be created in namespace"))
 	})
 
-	if env.GetSMCPVersion().LessThanOrEqual(version.SMCP_2_5) {
+	// jaeger is not available on SMCP 2.6 or OCP 4.19+, so use Jaeger tracing only for SMCP 2.5 and lower and OCP 4.18 and lower
+	if env.GetSMCPVersion().LessThanOrEqual(version.SMCP_2_5) && version.ParseVersion(oc.GetOCPVersion(t)).LessThanOrEqual(version.OCP_4_18) {
 		retry.UntilSuccess(t, func(t TestHelper) {
 			oc.Get(t,
 				meshNamespace,

--- a/pkg/tests/ossm/yaml/smcp.yaml
+++ b/pkg/tests/ossm/yaml/smcp.yaml
@@ -20,6 +20,7 @@ spec:
   version: {{ .Version }}
   tracing:
     sampling: 10000
+    type: {{ .TracingType }}
   policy:
     type: Istiod
   addons:

--- a/pkg/tests/tasks/migration/cert_manager_test.go
+++ b/pkg/tests/tasks/migration/cert_manager_test.go
@@ -55,7 +55,7 @@ func TestCertManagerMigration(t *testing.T) {
 		t.LogStep("Add jetstack repo to helm")
 		helm.Repo("https://charts.jetstack.io").Add(t, "jetstack")
 
-		smcp := ossm.DefaultClusterWideSMCP()
+		smcp := ossm.DefaultClusterWideSMCP(t)
 		smcp.Namespace = meshNamespace
 		istio := ossm.DefaultIstio()
 		istio.Template = istioWithCertManager

--- a/pkg/tests/tasks/migration/migration_test.go
+++ b/pkg/tests/tasks/migration/migration_test.go
@@ -49,7 +49,7 @@ func TestMigrationSimpleClusterWide(t *testing.T) {
 		})
 
 		t.LogStep("Install SMCP 2.6 in clusterwide mode")
-		smcp := ossm.DefaultClusterWideSMCP()
+		smcp := ossm.DefaultClusterWideSMCP(t)
 		istio := ossm.DefaultIstio()
 		// These are defaulted to the same but better to be explicit.
 		istio.Namespace = smcp.Namespace
@@ -169,7 +169,7 @@ func TestMigrationSimpleClusterWideLoadBalancer(t *testing.T) {
 		})
 
 		t.LogStep("Install SMCP 2.6 in clusterwide mode")
-		smcp := ossm.DefaultClusterWideSMCP()
+		smcp := ossm.DefaultClusterWideSMCP(t)
 		istio := ossm.DefaultIstio()
 		// These are defaulted to the same but better to be explicit.
 		istio.Namespace = smcp.Namespace

--- a/pkg/tests/tasks/traffic/egress/egress_gateways_test.go
+++ b/pkg/tests/tasks/traffic/egress/egress_gateways_test.go
@@ -29,8 +29,7 @@ func TestEgressGateways(t *testing.T) {
 		t.Cleanup(func() {
 			oc.RecreateNamespace(t, ns.Bookinfo)
 		})
-
-		ossm.DeployControlPlane(t)
+		smcp := ossm.DeployControlPlane(t)
 
 		t.LogStep("Install sleep pod")
 		app.InstallAndWaitReady(t, app.Sleep(ns.Bookinfo))

--- a/pkg/tests/tasks/traffic/egress/egress_gateways_tls_file_mount_test.go
+++ b/pkg/tests/tasks/traffic/egress/egress_gateways_tls_file_mount_test.go
@@ -38,7 +38,7 @@ func TestTLSOrigination(t *testing.T) {
 			app.Uninstall(t, app.Sleep(ns.Bookinfo))
 		})
 
-		ossm.DeployControlPlane(t)
+		smcp := ossm.DeployControlPlane(t)
 
 		t.LogStep("Install sleep pod")
 		app.InstallAndWaitReady(t, app.Sleep(ns.Bookinfo))

--- a/pkg/tests/tasks/traffic/egress/egress_gateways_tls_sds_test.go
+++ b/pkg/tests/tasks/traffic/egress/egress_gateways_tls_sds_test.go
@@ -26,6 +26,9 @@ import (
 
 func TestTLSOriginationSDS(t *testing.T) {
 	NewTest(t).Id("T15").Groups(Full, InterOp, ARM, Persistent).Run(func(t TestHelper) {
+		t.Log("Perform mTLS origination with an egress gateway")
+		smcp := ossm.DeployControlPlane(t)
+
 		t.Cleanup(func() {
 			oc.RecreateNamespace(t, ns.Bookinfo)
 			oc.RecreateNamespace(t, ns.MeshExternal)
@@ -33,9 +36,6 @@ func TestTLSOriginationSDS(t *testing.T) {
 			oc.DeleteFromTemplate(t, ns.Bookinfo, nginxTlsIstioMutualGateway, smcp)
 			oc.DeleteFromString(t, meshNamespace, nginxServiceEntry, originateMtlsSdsSToNginx)
 		})
-
-		t.Log("Perform mTLS origination with an egress gateway")
-		ossm.DeployControlPlane(t)
 
 		t.LogStep("Install sleep pod")
 		app.InstallAndWaitReady(t, app.Sleep(ns.Bookinfo))

--- a/pkg/tests/tasks/traffic/egress/egress_wildcard_hosts_test.go
+++ b/pkg/tests/tasks/traffic/egress/egress_wildcard_hosts_test.go
@@ -30,7 +30,7 @@ func TestEgressWildcard(t *testing.T) {
 	NewTest(t).Id("T16").Groups(Full, InterOp, ARM, Persistent).Run(func(t TestHelper) {
 		t.Log("This test checks if the wildcard in the ServiceEntry and Gateway works as expected for Egress traffic.")
 
-		ossm.DeployControlPlane(t)
+		smcp := ossm.DeployControlPlane(t)
 
 		t.LogStep("Install the sleep pod")
 		app.InstallAndWaitReady(t, app.Sleep(ns.Bookinfo))

--- a/pkg/tests/tasks/traffic/egress/yaml_vars.go
+++ b/pkg/tests/tasks/traffic/egress/yaml_vars.go
@@ -17,7 +17,6 @@ package egress
 import (
 	_ "embed"
 
-	"github.com/maistra/maistra-test-tool/pkg/tests/ossm"
 	"github.com/maistra/maistra-test-tool/pkg/util/env"
 )
 
@@ -29,7 +28,6 @@ var (
 
 var (
 	meshNamespace = env.GetDefaultMeshNamespace()
-	smcp          = ossm.DefaultSMCP()
 
 	//go:embed yaml/external-httpbin.yaml
 	httpbinServiceEntry string


### PR DESCRIPTION
- Do not use Jaeger tracing when SMCP is 2.5 but OCP version is 4.19+
- Cleaned up unnecessary DefaultSMCP calls
- Return SMCP values from `DeployControlPlane` method (so in the test, we don't need to call Default SMCP again, we will have available the same SMCP values as were applied for deployment)