### PR TITLE
Pin gotestsum to v1.12.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN microdnf install -y --nodocs tar gzip openssl findutils make git && \
 COPY . $HOME
 WORKDIR $HOME
 
-RUN go install gotest.tools/gotestsum@latest \
+RUN go install gotest.tools/gotestsum@v1.12.2 \
     && go mod download
 
 # Set required permissions for OpenShift usage


### PR DESCRIPTION
Replace @latest with 1.12.2
latest version 1.12.3 leads to:

```
STEP 11/13: RUN go install gotest.tools/gotestsum@latest     && go mod download
go: downloading gotest.tools/gotestsum v1.12.3
go: downloading gotest.tools v2.2.0+incompatible
go: gotest.tools/gotestsum@latest (in gotest.tools/gotestsum@v1.12.3): go.mod:3: invalid go version '1.23.0': must match format 1.23
Error: building at STEP "RUN go install gotest.tools/gotestsum@latest     && go mod download": while running runtime: exit status 1
make: *** [Makefile:44: image] Error 1
```

During `make image` operation